### PR TITLE
Rename project and library to tacuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(cuda_talib LANGUAGES CXX CUDA)
+project(tacuda LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)
@@ -13,29 +13,29 @@ file(GLOB INDICATOR_SOURCES
     src/indicators/*.cu
 )
 
-add_library(cuda_talib_shared SHARED
+add_library(tacuda SHARED
     ${INDICATOR_SOURCES}
     src/api/api.cpp
 )
 
 find_package(CUDAToolkit REQUIRED)
-target_link_libraries(cuda_talib_shared PRIVATE CUDA::cudart)
-target_compile_features(cuda_talib_shared PRIVATE cxx_std_17)
-target_compile_options(cuda_talib_shared PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
+target_link_libraries(tacuda PRIVATE CUDA::cudart)
+target_compile_features(tacuda PRIVATE cxx_std_17)
+target_compile_options(tacuda PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
 
 add_executable(example_app src/main.cpp)
-target_link_libraries(example_app PRIVATE cuda_talib_shared)
+target_link_libraries(example_app PRIVATE tacuda)
 
 # Tests (simple CTest with a small program using the C API)
 if (BUILD_TESTING)
   enable_testing()
   add_executable(test_basic tests/cpp/test_basic.cpp)
-  target_link_libraries(test_basic PRIVATE cuda_talib_shared)
+  target_link_libraries(test_basic PRIVATE tacuda)
   add_test(NAME run_test_basic COMMAND test_basic)
 endif()
 
 # Install (optional)
-install(TARGETS cuda_talib_shared example_app
+install(TARGETS tacuda example_app
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)

--- a/bindings/csharp/CudaTaLib.cs
+++ b/bindings/csharp/CudaTaLib.cs
@@ -6,11 +6,11 @@ namespace CudaTaLib
     public static class Native
     {
         #if WINDOWS
-            const string LIB = "cuda_talib_shared.dll";
+            const string LIB = "tacuda.dll";
         #elif OSX
-            const string LIB = "libcuda_talib_shared.dylib";
+            const string LIB = "libtacuda.dylib";
         #else
-            const string LIB = "libcuda_talib_shared.so";
+            const string LIB = "libtacuda.so";
         #endif
 
         [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]

--- a/bindings/csharp/README.md
+++ b/bindings/csharp/README.md
@@ -6,4 +6,4 @@ dotnet new console -n CudaTaLibExample
 # Replace Program.cs with CudaTaLib.cs contents or include as a separate file.
 dotnet run --project CudaTaLibExample
 ```
-Ensure the native `cuda_talib_shared` is discoverable (same dir or on PATH/LD_LIBRARY_PATH/DYLD_LIBRARY_PATH).
+Ensure the native `tacuda` library is discoverable (same dir or on PATH/LD_LIBRARY_PATH/DYLD_LIBRARY_PATH).

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -3,11 +3,11 @@
 Usage:
 ```python
 import numpy as np
-from cuda_talib import sma, momentum, macd_line
+from tacuda import sma, momentum, macd_line
 
 x = np.random.rand(1024).astype(np.float32)
 print(sma(x, 14)[:10])
 print(momentum(x, 10)[:10])
 print(macd_line(x)[:10])
 ```
-Make sure you've built the shared library (`cuda_talib_shared`) so the bindings can locate it.
+Make sure you've built the shared library (`tacuda`) so the bindings can locate it.

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -1,6 +1,6 @@
 """
-Python bindings for cuda_talib via ctypes.
-Build the project first (shared library 'cuda_talib_shared').
+Python bindings for tacuda via ctypes.
+Build the project first (shared library 'tacuda').
 """
 import ctypes
 import os
@@ -9,11 +9,11 @@ import sys
 def _load_lib():
     names = []
     if sys.platform.startswith("win"):
-        names = ["cuda_talib_shared.dll"]
+        names = ["tacuda.dll"]
     elif sys.platform == "darwin":
-        names = ["libcuda_talib_shared.dylib", "cuda_talib_shared.dylib"]
+        names = ["libtacuda.dylib", "tacuda.dylib"]
     else:
-        names = ["libcuda_talib_shared.so", "cuda_talib_shared.so"]
+        names = ["libtacuda.so", "tacuda.so"]
     search_paths = [os.getcwd(), os.path.join(os.getcwd(), "build"), os.path.dirname(__file__),
                     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "build"))]
     for base in search_paths:
@@ -21,7 +21,7 @@ def _load_lib():
             p = os.path.join(base, n)
             if os.path.exists(p):
                 return ctypes.CDLL(p)
-    raise OSError("cuda_talib_shared library not found. Build the project first.")
+    raise OSError("tacuda library not found. Build the project first.")
 
 _lib = _load_lib()
 

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -1,5 +1,5 @@
-#ifndef CUDA_TALIB_H
-#define CUDA_TALIB_H
+#ifndef TACUDA_H
+#define TACUDA_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -26,4 +26,4 @@ CTAPI_EXPORT int ct_macd_line(const float* host_input, float* host_output, int s
 } // extern "C"
 #endif
 
-#endif
+#endif // TACUDA_H

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -3,7 +3,7 @@
 #include <cstring>
 #include <cuda_runtime.h>
 
-#include "../../include/cuda_talib.h"
+#include "../../include/tacuda.h"
 #include "../../include/indicators/SMA.h"
 #include "../../include/indicators/Momentum.h"
 #include "../../include/indicators/MACD.h"

--- a/tests/cpp/test_basic.cpp
+++ b/tests/cpp/test_basic.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 #include <cmath>
 #include <cassert>
-#include "../../include/cuda_talib.h"
+#include "../../include/tacuda.h"
 
 static void approx_equal(const std::vector<float>& a, const std::vector<float>& b, float eps=1e-3f) {
     for (size_t i=0;i<a.size();++i) {


### PR DESCRIPTION
## Summary
- Rename CMake project and library target to `tacuda`
- Rename public header to `tacuda.h` and update includes
- Adjust Python and C# bindings to load the `tacuda` library

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Release .. && cmake --build . -j 2 && ctest --output-on-failure` *(failed: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ccbd3ee08329bff1d6b6211cc09c