### PR TITLE
Use target-specific includes and update headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 
 option(BUILD_TESTING "Enable tests" ON)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-
 file(GLOB INDICATOR_SOURCES
     src/indicators/*.cu
 )
@@ -16,6 +14,12 @@ file(GLOB INDICATOR_SOURCES
 add_library(tacuda SHARED
     ${INDICATOR_SOURCES}
     src/api/api.cpp
+)
+
+target_include_directories(tacuda
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
 )
 
 find_package(CUDAToolkit REQUIRED)

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -3,11 +3,11 @@
 #include <cstring>
 #include <cuda_runtime.h>
 
-#include "../../include/tacuda.h"
-#include "../../include/indicators/SMA.h"
-#include "../../include/indicators/Momentum.h"
-#include "../../include/indicators/MACD.h"
-#include "../../include/utils/CudaUtils.h"
+#include "tacuda.h"
+#include <indicators/SMA.h>
+#include <indicators/Momentum.h>
+#include <indicators/MACD.h>
+#include <utils/CudaUtils.h>
 
 extern "C" {
 

--- a/src/indicators/MACD.cu
+++ b/src/indicators/MACD.cu
@@ -1,7 +1,7 @@
 #include <algorithm>
 #include <stdexcept>
-#include "../../include/indicators/MACD.h"
-#include "../../include/utils/CudaUtils.h"
+#include <indicators/MACD.h>
+#include <utils/CudaUtils.h>
 
 __device__ float ema_at(const float* __restrict__ x, int idx, int period) {
     float k = 2.0f / (period + 1.0f);

--- a/src/indicators/Momentum.cu
+++ b/src/indicators/Momentum.cu
@@ -1,5 +1,5 @@
-#include "../../include/indicators/Momentum.h"
-#include "../../include/utils/CudaUtils.h"
+#include <indicators/Momentum.h>
+#include <utils/CudaUtils.h>
 #include <stdexcept>
 
 __global__ void momentumKernel(const float* __restrict__ input, float* __restrict__ output,

--- a/src/indicators/SMA.cu
+++ b/src/indicators/SMA.cu
@@ -1,5 +1,5 @@
-#include "../../include/indicators/SMA.h"
-#include "../../include/utils/CudaUtils.h"
+#include <indicators/SMA.h>
+#include <utils/CudaUtils.h>
 #include <stdexcept>
 
 __global__ void smaKernel(const float* __restrict__ input, float* __restrict__ output,


### PR DESCRIPTION
## Summary
- Swap global include_directories for target_include_directories so tacuda exports its headers cleanly.
- Replace relative includes in API and indicator sources with project-root style paths.

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cfd867d8832989bfd288055953d2