### PR TITLE
Use RAII for device buffers and expose error codes

### DIFF
--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -14,12 +14,18 @@
 extern "C" {
 #endif
 
+typedef enum ctStatus {
+    CT_STATUS_SUCCESS = 0,
+    CT_STATUS_ALLOC_FAILED = 1,
+    CT_STATUS_COPY_FAILED = 2,
+    CT_STATUS_KERNEL_FAILED = 3,
+} ctStatus_t;
+
 // All APIs copy host->device->host internally for ease of binding.
-// Returns 0 on success, non-zero on failure.
-CTAPI_EXPORT int ct_sma(const float* host_input, float* host_output, int size, int period);
-CTAPI_EXPORT int ct_momentum(const float* host_input, float* host_output, int size, int period);
+CTAPI_EXPORT ctStatus_t ct_sma(const float* host_input, float* host_output, int size, int period);
+CTAPI_EXPORT ctStatus_t ct_momentum(const float* host_input, float* host_output, int size, int period);
 // MACD line only (EMA_fast - EMA_slow)
-CTAPI_EXPORT int ct_macd_line(const float* host_input, float* host_output, int size,
+CTAPI_EXPORT ctStatus_t ct_macd_line(const float* host_input, float* host_output, int size,
                               int fastPeriod, int slowPeriod, int signalPeriod);
 
 #ifdef __cplusplus

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -2,6 +2,7 @@
 #include <stdexcept>
 #include <cstring>
 #include <cuda_runtime.h>
+#include <memory>
 
 #include "tacuda.h"
 #include <indicators/SMA.h>
@@ -11,35 +12,59 @@
 
 extern "C" {
 
-static int run_indicator(Indicator& ind, const float* h_in, float* h_out, int size) {
-    try {
-        float *d_in=nullptr, *d_out=nullptr;
-        CUDA_CHECK(cudaMalloc(&d_in, size * sizeof(float)));
-        CUDA_CHECK(cudaMalloc(&d_out, size * sizeof(float)));
-        CUDA_CHECK(cudaMemcpy(d_in, h_in, size * sizeof(float), cudaMemcpyHostToDevice));
-
-        ind.calculate(d_in, d_out, size);
-
-        CUDA_CHECK(cudaMemcpy(h_out, d_out, size * sizeof(float), cudaMemcpyDeviceToHost));
-        CUDA_CHECK(cudaFree(d_in));
-        CUDA_CHECK(cudaFree(d_out));
-        return 0;
-    } catch (...) {
-        return 1;
+struct CudaDeleter {
+    void operator()(float* ptr) const noexcept {
+        if (ptr) cudaFree(ptr);
     }
+};
+using DeviceBuffer = std::unique_ptr<float, CudaDeleter>;
+
+static ctStatus_t run_indicator(Indicator& ind, const float* h_in, float* h_out, int size) {
+    DeviceBuffer d_in{nullptr}, d_out{nullptr};
+    float* tmp = nullptr;
+
+    cudaError_t err = cudaMalloc(&tmp, size * sizeof(float));
+    if (err != cudaSuccess) {
+        return CT_STATUS_ALLOC_FAILED;
+    }
+    d_in.reset(tmp);
+
+    err = cudaMalloc(&tmp, size * sizeof(float));
+    if (err != cudaSuccess) {
+        return CT_STATUS_ALLOC_FAILED;
+    }
+    d_out.reset(tmp);
+
+    err = cudaMemcpy(d_in.get(), h_in, size * sizeof(float), cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) {
+        return CT_STATUS_COPY_FAILED;
+    }
+
+    try {
+        ind.calculate(d_in.get(), d_out.get(), size);
+    } catch (...) {
+        return CT_STATUS_KERNEL_FAILED;
+    }
+
+    err = cudaMemcpy(h_out, d_out.get(), size * sizeof(float), cudaMemcpyDeviceToHost);
+    if (err != cudaSuccess) {
+        return CT_STATUS_COPY_FAILED;
+    }
+
+    return CT_STATUS_SUCCESS;
 }
 
-int ct_sma(const float* host_input, float* host_output, int size, int period) {
+ctStatus_t ct_sma(const float* host_input, float* host_output, int size, int period) {
     SMA sma(period);
     return run_indicator(sma, host_input, host_output, size);
 }
 
-int ct_momentum(const float* host_input, float* host_output, int size, int period) {
+ctStatus_t ct_momentum(const float* host_input, float* host_output, int size, int period) {
     Momentum mom(period);
     return run_indicator(mom, host_input, host_output, size);
 }
 
-int ct_macd_line(const float* host_input, float* host_output, int size,
+ctStatus_t ct_macd_line(const float* host_input, float* host_output, int size,
                  int fastPeriod, int slowPeriod, int signalPeriod) {
     MACD macd(fastPeriod, slowPeriod, signalPeriod);
     return run_indicator(macd, host_input, host_output, size);

--- a/tests/cpp/test_basic.cpp
+++ b/tests/cpp/test_basic.cpp
@@ -24,8 +24,8 @@ int main() {
 
     // SMA check vs CPU naive
     int p = 5;
-    int rc = ct_sma(x.data(), out.data(), N, p);
-    if (rc != 0) { std::cerr << "ct_sma failed\\n"; return 1; }
+    ctStatus_t rc = ct_sma(x.data(), out.data(), N, p);
+    if (rc != CT_STATUS_SUCCESS) { std::cerr << "ct_sma failed\\n"; return 1; }
     for (int i=0;i<=N-p;i++) {
         float s=0; for (int k=0;k<p;k++) s+=x[i+k];
         ref[i] = s/p;
@@ -35,13 +35,13 @@ int main() {
     // Momentum check
     std::fill(ref.begin(), ref.end(), 0.0f);
     rc = ct_momentum(x.data(), out.data(), N, p);
-    if (rc != 0) { std::cerr << "ct_momentum failed\\n"; return 1; }
+    if (rc != CT_STATUS_SUCCESS) { std::cerr << "ct_momentum failed\\n"; return 1; }
     for (int i=0;i<N-p;i++) ref[i] = x[i+p]-x[i];
     approx_equal(out, ref, 1e-3f);
 
     // MACD line smoke test (can't exact-match recursive EMA easily) — ensure finite values
     rc = ct_macd_line(x.data(), out.data(), N, 12, 26, 9);
-    if (rc != 0) { std::cerr << "ct_macd_line failed\\n"; return 1; }
+    if (rc != CT_STATUS_SUCCESS) { std::cerr << "ct_macd_line failed\\n"; return 1; }
     for (int i=0;i<N;i++) { if (!std::isfinite(out[i])) { std::cerr << "nan at " << i << "\\n"; return 1; } }
 
     std::cout << "All tests passed.\\n";


### PR DESCRIPTION
## Summary
- manage device memory with RAII unique_ptrs so buffers are freed on errors
- surface explicit allocation/copy/kernel error codes via the C API
- adjust tests to check for new status values

## Testing
- `cmake ..` *(fails: Failed to find nvcc. Compiler requires the CUDA toolkit)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d1126c588329b954bdfbaacb7783