### PR TITLE
Clarify Indicator destructor and exception contract

### DIFF
--- a/include/indicators/Indicator.h
+++ b/include/indicators/Indicator.h
@@ -3,8 +3,8 @@
 
 class Indicator {
 public:
-    virtual void calculate(const float* input, float* output, int size) = 0;
-    virtual ~Indicator() {};
+    virtual void calculate(const float* input, float* output, int size) noexcept(false) = 0;
+    virtual ~Indicator() = default;
 };
 
 #endif

--- a/include/indicators/MACD.h
+++ b/include/indicators/MACD.h
@@ -6,7 +6,7 @@
 class MACD : public Indicator {
 public:
     MACD(int fastPeriod, int slowPeriod);
-    void calculate(const float* input, float* output, int size) override;
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
 private:
     int fastPeriod;
     int slowPeriod;

--- a/include/indicators/Momentum.h
+++ b/include/indicators/Momentum.h
@@ -6,7 +6,7 @@
 class Momentum : public Indicator {
 public:
     explicit Momentum(int period);
-    void calculate(const float* input, float* output, int size) override;
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
 private:
     int period;
 };

--- a/include/indicators/SMA.h
+++ b/include/indicators/SMA.h
@@ -6,7 +6,7 @@
 class SMA : public Indicator {
 public:
     explicit SMA(int period);
-    void calculate(const float* input, float* output, int size) override;
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
 private:
     int period;
 };

--- a/src/indicators/MACD.cu
+++ b/src/indicators/MACD.cu
@@ -27,7 +27,7 @@ __global__ void macdKernel(const float* __restrict__ input,
 MACD::MACD(int fastPeriod, int slowPeriod)
     : fastPeriod(fastPeriod), slowPeriod(slowPeriod) {}
 
-void MACD::calculate(const float* input, float* output, int size) {
+void MACD::calculate(const float* input, float* output, int size) noexcept(false) {
     if (fastPeriod <= 0 || slowPeriod <= 0) {
         throw std::invalid_argument("MACD: invalid periods");
     }

--- a/src/indicators/Momentum.cu
+++ b/src/indicators/Momentum.cu
@@ -12,7 +12,7 @@ __global__ void momentumKernel(const float* __restrict__ input, float* __restric
 
 Momentum::Momentum(int period) : period(period) {}
 
-void Momentum::calculate(const float* input, float* output, int size) {
+void Momentum::calculate(const float* input, float* output, int size) noexcept(false) {
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("Momentum: invalid period");
     }

--- a/src/indicators/SMA.cu
+++ b/src/indicators/SMA.cu
@@ -17,7 +17,7 @@ __global__ void smaKernelPrefix(const float* __restrict__ prefix,
 
 SMA::SMA(int period) : period(period) {}
 
-void SMA::calculate(const float* input, float* output, int size) {
+void SMA::calculate(const float* input, float* output, int size) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("SMA: invalid period");
     }


### PR DESCRIPTION
## Summary
- Default the virtual destructor of Indicator
- Specify that calculate may throw via `noexcept(false)` in Indicator and its derived classes

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d98b31c883299e6477b95b96ac32