### PR TITLE
Add GoogleTest and convert basic tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,18 @@ target_link_libraries(example_app PRIVATE tacuda)
 # Tests (simple CTest with a small program using the C API)
 if (BUILD_TESTING)
   enable_testing()
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.14.0
+  )
+  FetchContent_MakeAvailable(googletest)
+
   add_executable(test_basic tests/cpp/test_basic.cpp)
-  target_link_libraries(test_basic PRIVATE tacuda)
-  add_test(NAME run_test_basic COMMAND test_basic)
+  target_link_libraries(test_basic PRIVATE tacuda GTest::gtest_main)
+  include(GoogleTest)
+  gtest_discover_tests(test_basic)
 endif()
 
 # Install (optional)

--- a/tests/cpp/test_basic.cpp
+++ b/tests/cpp/test_basic.cpp
@@ -1,61 +1,81 @@
-#include <iostream>
-#include <vector>
+#include <algorithm>
 #include <cmath>
-#include <cassert>
-#include "../../include/tacuda.h"
+#include <gtest/gtest.h>
+#include <tacuda.h>
+#include <vector>
 
-static void approx_equal(const std::vector<float>& a, const std::vector<float>& b, float eps=1e-3f) {
-    for (size_t i=0;i<a.size();++i) {
-        if (std::isnan(a[i]) || std::isnan(b[i])) continue;
-        float d = std::fabs(a[i]-b[i]);
-        if (d > eps) {
-            std::cerr << "Mismatch at " << i << ": " << a[i] << " vs " << b[i] << std::endl;
-            assert(false);
-        }
-    }
+namespace {
+
+// Helper to compare floating point vectors, ignoring NaNs.
+void expect_approx_equal(const std::vector<float> &a,
+                         const std::vector<float> &b, float eps = 1e-3f) {
+  ASSERT_EQ(a.size(), b.size());
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (std::isnan(a[i]) || std::isnan(b[i]))
+      continue;
+    EXPECT_NEAR(a[i], b[i], eps) << "Mismatch at index " << i;
+  }
 }
 
-int main() {
-    const int N = 128;
-    std::vector<float> x(N);
-    for (int i = 0; i < N; ++i) x[i] = std::sin(0.05f * i);
+} // namespace
 
-    std::vector<float> out(N, 0.0f), ref(N, 0.0f);
+TEST(Tacuda, SMA) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
 
-    // SMA check vs CPU naive
-    int p = 5;
-    ctStatus_t rc = ct_sma(x.data(), out.data(), N, p);
-    if (rc != CT_STATUS_SUCCESS) { std::cerr << "ct_sma failed\\n"; return 1; }
-    for (int i=0;i<=N-p;i++) {
-        float s=0; for (int k=0;k<p;k++) s+=x[i+k];
-        ref[i] = s/p;
-    }
-    approx_equal(out, ref, 1e-3f);
-    for (int i=N-p+1;i<N;i++) {
-        if (!std::isnan(out[i])) { std::cerr << "expected NaN at tail " << i << "\n"; return 1; }
-    }
+  std::vector<float> out(N, 0.0f), ref(N, 0.0f);
 
-    // Momentum check
-    std::fill(ref.begin(), ref.end(), 0.0f);
-    rc = ct_momentum(x.data(), out.data(), N, p);
-    if (rc != CT_STATUS_SUCCESS) { std::cerr << "ct_momentum failed\\n"; return 1; }
-    for (int i=0;i<N-p;i++) ref[i] = x[i+p]-x[i];
-    approx_equal(out, ref, 1e-3f);
-    for (int i=N-p;i<N;i++) {
-        if (!std::isnan(out[i])) { std::cerr << "expected NaN at tail " << i << "\n"; return 1; }
-    }
+  int p = 5;
+  ctStatus_t rc = ct_sma(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_sma failed";
+  for (int i = 0; i <= N - p; i++) {
+    float s = 0.0f;
+    for (int k = 0; k < p; k++)
+      s += x[i + k];
+    ref[i] = s / p;
+  }
+  expect_approx_equal(out, ref);
+  for (int i = N - p + 1; i < N; i++) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at tail " << i;
+  }
+}
 
-    // MACD line smoke test — first `slowPeriod` samples should be NaN, rest finite
-    int fastP = 12, slowP = 26;
-    rc = ct_macd_line(x.data(), out.data(), N, fastP, slowP);
-    if (rc != CT_STATUS_SUCCESS) { std::cerr << "ct_macd_line failed\\n"; return 1; }
-    for (int i=0;i<slowP;i++) {
-        if (!std::isnan(out[i])) { std::cerr << "expected NaN at head " << i << "\\n"; return 1; }
-    }
-    for (int i=slowP;i<N;i++) {
-        if (!std::isfinite(out[i])) { std::cerr << "nan at " << i << "\\n"; return 1; }
-    }
+TEST(Tacuda, Momentum) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
 
-    std::cout << "All tests passed.\\n";
-    return 0;
+  std::vector<float> out(N, 0.0f), ref(N, 0.0f);
+
+  int p = 5;
+  ctStatus_t rc = ct_momentum(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_momentum failed";
+  for (int i = 0; i < N - p; i++)
+    ref[i] = x[i + p] - x[i];
+  expect_approx_equal(out, ref);
+  for (int i = N - p; i < N; i++) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at tail " << i;
+  }
+}
+
+TEST(Tacuda, MacdLine) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+
+  std::vector<float> out(N, 0.0f);
+
+  int fastP = 12, slowP = 26;
+  ctStatus_t rc = ct_macd_line(x.data(), out.data(), N, fastP, slowP);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_macd_line failed";
+  for (int i = 0; i < slowP; i++) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
+  }
+  for (int i = slowP; i < N; i++) {
+    EXPECT_TRUE(std::isfinite(out[i])) << "expected finite value at " << i;
+  }
 }


### PR DESCRIPTION
## Summary
- fetch GoogleTest with CMake and auto-discover tests
- rewrite basic C API checks as GoogleTest cases

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `ctest --test-dir build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6db5aef208329b8db2aaf57e26546