### PR TITLE
Add OBV indicator and bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(INDICATOR_SOURCES
     src/indicators/ATR.cu
     src/indicators/Stochastic.cu
     src/indicators/CCI.cu
+    src/indicators/OBV.cu
 )
 
 add_library(tacuda SHARED

--- a/bindings/csharp/CudaTaLib.cs
+++ b/bindings/csharp/CudaTaLib.cs
@@ -40,6 +40,10 @@ namespace CudaTaLib
         [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
         public static extern int ct_cci(float[] high, float[] low, float[] close,
                                         float[] output, int size, int period);
+
+        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int ct_obv(float[] price, float[] volume,
+                                        float[] output, int size);
     }
 
     public class Example

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -90,6 +90,9 @@ _lib.ct_cci.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_
                         ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
                         ctypes.c_int, ctypes.c_int]
 _lib.ct_cci.restype  = ctypes.c_int
+_lib.ct_obv.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                        ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_obv.restype  = ctypes.c_int
 
 def _as_float_ptr(arr):
     import numpy as np
@@ -205,4 +208,19 @@ def cci(high, low, close, period):
     rc = _lib.ct_cci(ph, pl, pc, pout, close.size, int(period))
     if rc != 0:
         raise RuntimeError("ct_cci failed")
+    return out
+
+def obv(price, volume):
+    import numpy as np
+    price = np.asarray(price, dtype=np.float32)
+    volume = np.asarray(volume, dtype=np.float32)
+    if price.shape != volume.shape:
+        raise ValueError("price and volume must have same shape")
+    out = np.zeros_like(price)
+    _, pp = _as_float_ptr(price)
+    _, pv = _as_float_ptr(volume)
+    _, po = _as_float_ptr(out)
+    rc = _lib.ct_obv(pp, pv, po, price.size)
+    if rc != 0:
+        raise RuntimeError("ct_obv failed")
     return out

--- a/include/indicators/OBV.h
+++ b/include/indicators/OBV.h
@@ -1,0 +1,14 @@
+#ifndef OBV_H
+#define OBV_H
+
+#include "Indicator.h"
+
+class OBV : public Indicator {
+public:
+    OBV() = default;
+    void calculate(const float* price, const float* volume,
+                   float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -59,6 +59,10 @@ CTAPI_EXPORT ctStatus_t ct_cci(const float* host_high,
                                float* host_output,
                                int size,
                                int period);
+CTAPI_EXPORT ctStatus_t ct_obv(const float* host_price,
+                               const float* host_volume,
+                               float* host_output,
+                               int size);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/indicators/OBV.cu
+++ b/src/indicators/OBV.cu
@@ -1,0 +1,43 @@
+#include <indicators/OBV.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+
+__global__ void obvKernel(const float* __restrict__ price,
+                          const float* __restrict__ volume,
+                          float* __restrict__ output,
+                          int size) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        if (size <= 0) return;
+        float prevPrice = price[0];
+        float obv = volume[0];
+        output[0] = obv;
+        for (int i = 1; i < size; ++i) {
+            float p = price[i];
+            float v = volume[i];
+            if (p > prevPrice) {
+                obv += v;
+            } else if (p < prevPrice) {
+                obv -= v;
+            }
+            output[i] = obv;
+            prevPrice = p;
+        }
+    }
+}
+
+void OBV::calculate(const float* price, const float* volume,
+                    float* output, int size) noexcept(false) {
+    if (size <= 0) {
+        throw std::invalid_argument("OBV: invalid size");
+    }
+    obvKernel<<<1,1>>>(price, volume, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void OBV::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* price = input;
+    const float* volume = input + size;
+    calculate(price, volume, output, size);
+}
+

--- a/tests/cpp/test_basic.cpp
+++ b/tests/cpp/test_basic.cpp
@@ -337,3 +337,14 @@ TEST(Tacuda, CCI) {
     EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
   }
 }
+
+TEST(Tacuda, OBV) {
+  std::vector<float> price = {1.0f, 2.0f, 2.0f, 1.0f, 3.0f};
+  std::vector<float> volume = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f};
+  const int N = price.size();
+  std::vector<float> out(N, 0.0f), ref = {10.0f, 30.0f, 30.0f, -10.0f, 40.0f};
+
+  ctStatus_t rc = ct_obv(price.data(), volume.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_obv failed";
+  expect_approx_equal(out, ref);
+}


### PR DESCRIPTION
## Summary
- implement On-Balance Volume indicator and expose via ct_obv
- add OBV to Python and C# bindings
- add OBV unit test and build integration

## Testing
- ⚠️ `cmake ..` (failed: Failed to find nvcc. Compiler requires the CUDA toolkit. Please set the CUDAToolkit_ROOT variable.)

------
https://chatgpt.com/codex/tasks/task_e_68a735e5993c83299e7f51d1b9727ca4