### PR TITLE
Add Chaikin oscillator indicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(INDICATOR_SOURCES
     src/indicators/SAR.cu
     src/indicators/ADX.cu
     src/indicators/Aroon.cu
+    src/indicators/ADOSC.cu
 )
 
 add_library(tacuda SHARED

--- a/include/indicators/ADOSC.h
+++ b/include/indicators/ADOSC.h
@@ -1,0 +1,17 @@
+#ifndef ADOSC_H
+#define ADOSC_H
+
+#include "Indicator.h"
+
+class ADOSC : public Indicator {
+public:
+    ADOSC(int shortPeriod, int longPeriod);
+    void calculate(const float* high, const float* low, const float* close,
+                   const float* volume, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int shortPeriod;
+    int longPeriod;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -83,6 +83,14 @@ CTAPI_EXPORT ctStatus_t ct_aroon(const float* host_high,
                                  int size,
                                  int upPeriod,
                                  int downPeriod);
+CTAPI_EXPORT ctStatus_t ct_adosc(const float* host_high,
+                                 const float* host_low,
+                                 const float* host_close,
+                                 const float* host_volume,
+                                 float* host_output,
+                                 int size,
+                                 int shortPeriod,
+                                 int longPeriod);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/indicators/ADOSC.cu
+++ b/src/indicators/ADOSC.cu
@@ -1,0 +1,84 @@
+#include <indicators/ADOSC.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+#include <algorithm>
+
+__global__ void adLineKernel(const float* __restrict__ high,
+                             const float* __restrict__ low,
+                             const float* __restrict__ close,
+                             const float* __restrict__ volume,
+                             float* __restrict__ ad,
+                             int size) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        float cum = 0.0f;
+        for (int i = 0; i < size; ++i) {
+            float h = high[i];
+            float l = low[i];
+            float c = close[i];
+            float v = volume[i];
+            float denom = h - l;
+            float clv = denom == 0.0f ? 0.0f : ((c - l) - (h - c)) / denom;
+            cum += clv * v;
+            ad[i] = cum;
+        }
+    }
+}
+
+__device__ float ema_at(const float* __restrict__ x, int idx, int period) {
+    const float k = 2.0f / (period + 1.0f);
+    float weight = 1.0f;
+    float weightedSum = x[idx];
+    float weightSum = 1.0f;
+    int steps = min(period, idx);
+#pragma unroll
+    for (int i = 1; i <= steps; ++i) {
+        weight *= (1.0f - k);
+        weightedSum += x[idx - i] * weight;
+        weightSum += weight;
+    }
+    return weightedSum / weightSum;
+}
+
+__global__ void adoscKernel(const float* __restrict__ ad,
+                            float* __restrict__ output,
+                            int shortP, int longP, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= longP && idx < size) {
+        float emaShort = ema_at(ad, idx, shortP);
+        float emaLong = ema_at(ad, idx, longP);
+        output[idx] = emaShort - emaLong;
+    }
+}
+
+ADOSC::ADOSC(int shortPeriod, int longPeriod)
+    : shortPeriod(shortPeriod), longPeriod(longPeriod) {}
+
+void ADOSC::calculate(const float* high, const float* low, const float* close,
+                      const float* volume, float* output, int size) noexcept(false) {
+    if (shortPeriod <= 0 || longPeriod <= 0) {
+        throw std::invalid_argument("ADOSC: invalid periods");
+    }
+    if (shortPeriod >= longPeriod) {
+        throw std::invalid_argument("ADOSC: shortPeriod must be < longPeriod");
+    }
+    float* ad = nullptr;
+    CUDA_CHECK(cudaMalloc(&ad, size * sizeof(float)));
+
+    adLineKernel<<<1,1>>>(high, low, close, volume, ad, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    adoscKernel<<<grid, block>>>(ad, output, shortPeriod, longPeriod, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaFree(ad));
+}
+
+void ADOSC::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* high = input;
+    const float* low = input + size;
+    const float* close = input + 2 * size;
+    const float* volume = input + 3 * size;
+    calculate(high, low, close, volume, output, size);
+}

--- a/tests/cpp/test_basic.cpp
+++ b/tests/cpp/test_basic.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <gtest/gtest.h>
 #include <tacuda.h>
 #include <vector>
@@ -393,6 +394,62 @@ TEST(Tacuda, OBV) {
   ctStatus_t rc = ct_obv(price.data(), volume.data(), out.data(), N);
   ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_obv failed";
   expect_approx_equal(out, ref);
+}
+
+namespace {
+std::vector<float> adosc_ref(const std::vector<float>& high,
+                             const std::vector<float>& low,
+                             const std::vector<float>& close,
+                             const std::vector<float>& volume,
+                             int shortP, int longP) {
+  int N = high.size();
+  std::vector<float> ad(N, 0.0f);
+  std::vector<float> out(N, std::numeric_limits<float>::quiet_NaN());
+  float cum = 0.0f;
+  for (int i = 0; i < N; ++i) {
+    float denom = high[i] - low[i];
+    float clv = denom == 0.0f ? 0.0f : ((close[i] - low[i]) - (high[i] - close[i])) / denom;
+    cum += clv * volume[i];
+    ad[i] = cum;
+  }
+  auto ema_at = [](const std::vector<float>& x, int idx, int period) {
+    const float k = 2.0f / (period + 1.0f);
+    float weight = 1.0f;
+    float weightedSum = x[idx];
+    float weightSum = 1.0f;
+    int steps = std::min(period, idx);
+    for (int i = 1; i <= steps; ++i) {
+      weight *= (1.0f - k);
+      weightedSum += x[idx - i] * weight;
+      weightSum += weight;
+    }
+    return weightedSum / weightSum;
+  };
+  for (int i = longP; i < N; ++i) {
+    float emaS = ema_at(ad, i, shortP);
+    float emaL = ema_at(ad, i, longP);
+    out[i] = emaS - emaL;
+  }
+  return out;
+}
+} // namespace
+
+TEST(Tacuda, ADOSC) {
+  std::vector<float> high   = {12.f, 12.5f, 13.f, 13.5f, 14.f, 14.5f};
+  std::vector<float> low    = {11.f, 11.5f, 12.f, 12.5f, 13.f, 13.5f};
+  std::vector<float> close  = {11.5f, 12.f, 12.5f, 13.f, 13.5f, 14.f};
+  std::vector<float> volume = {100.f, 110.f, 120.f, 130.f, 140.f, 150.f};
+  const int N = high.size();
+  std::vector<float> out(N, 0.0f);
+  int shortP = 3, longP = 5;
+  ctStatus_t rc = ct_adosc(high.data(), low.data(), close.data(), volume.data(),
+                           out.data(), N, shortP, longP);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_adosc failed";
+  auto ref = adosc_ref(high, low, close, volume, shortP, longP);
+  expect_approx_equal(out, ref);
+  for (int i = 0; i < longP; ++i) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
+  }
 }
 
 TEST(Tacuda, ADX) {


### PR DESCRIPTION
## Summary
- implement Chaikin oscillator (ADOSC) indicator with AD line and EMA difference
- expose new ct_adosc API entry and include in build
- test GPU ADOSC against CPU reference

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68a829e328808329acb5aadf15f9ebf6