### PR TITLE
Add TEMA indicator and API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(INDICATOR_SOURCES
     src/indicators/SMA.cu
     src/indicators/EMA.cu
     src/indicators/DEMA.cu
+    src/indicators/TEMA.cu
     src/indicators/WMA.cu
     src/indicators/RSI.cu
     src/indicators/BBANDS.cu

--- a/include/indicators/TEMA.h
+++ b/include/indicators/TEMA.h
@@ -1,0 +1,14 @@
+#ifndef TEMA_H
+#define TEMA_H
+
+#include "Indicator.h"
+
+class TEMA : public Indicator {
+public:
+    explicit TEMA(int period);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int period;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -28,6 +28,7 @@ CTAPI_EXPORT ctStatus_t ct_momentum(const float* host_input, float* host_output,
 CTAPI_EXPORT ctStatus_t ct_roc(const float* host_input, float* host_output, int size, int period);
 CTAPI_EXPORT ctStatus_t ct_ema(const float* host_input, float* host_output, int size, int period);
 CTAPI_EXPORT ctStatus_t ct_dema(const float* host_input, float* host_output, int size, int period);
+CTAPI_EXPORT ctStatus_t ct_tema(const float* host_input, float* host_output, int size, int period);
 CTAPI_EXPORT ctStatus_t ct_rsi(const float* host_input, float* host_output, int size, int period);
 // MACD line only (EMA_fast - EMA_slow)
 CTAPI_EXPORT ctStatus_t ct_macd_line(const float* host_input, float* host_output, int size,

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -11,6 +11,7 @@
 #include <indicators/MACD.h>
 #include <indicators/EMA.h>
 #include <indicators/DEMA.h>
+#include <indicators/TEMA.h>
 #include <indicators/WMA.h>
 #include <indicators/RSI.h>
 #include <indicators/BBANDS.h>
@@ -99,6 +100,11 @@ ctStatus_t ct_ema(const float* host_input, float* host_output, int size, int per
 ctStatus_t ct_dema(const float* host_input, float* host_output, int size, int period) {
     DEMA dema(period);
     return run_indicator(dema, host_input, host_output, size);
+}
+
+ctStatus_t ct_tema(const float* host_input, float* host_output, int size, int period) {
+    TEMA tema(period);
+    return run_indicator(tema, host_input, host_output, size);
 }
 
 ctStatus_t ct_rsi(const float* host_input, float* host_output, int size, int period) {

--- a/src/indicators/TEMA.cu
+++ b/src/indicators/TEMA.cu
@@ -1,0 +1,53 @@
+#include <indicators/TEMA.h>
+#include <indicators/EMA.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+
+__global__ void temaKernel(const float* __restrict__ ema1,
+                           const float* __restrict__ ema2,
+                           const float* __restrict__ ema3,
+                           float* __restrict__ output,
+                           int period,
+                           int valid) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < valid) {
+        output[idx] = 3.0f * ema1[idx + 2 * (period - 1)]
+                    - 3.0f * ema2[idx + (period - 1)]
+                    + ema3[idx];
+    }
+}
+
+TEMA::TEMA(int period) : period(period) {}
+
+void TEMA::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (period <= 0 || size < 3 * period - 2) {
+        throw std::invalid_argument("TEMA: invalid period");
+    }
+
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+
+    float* ema1 = nullptr;
+    float* ema2 = nullptr;
+    float* ema3 = nullptr;
+    CUDA_CHECK(cudaMalloc(&ema1, size * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&ema2, size * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&ema3, size * sizeof(float)));
+
+    EMA ema(period);
+    ema.calculate(input, ema1, size);
+    int size2 = size - period + 1;
+    ema.calculate(ema1, ema2, size2);
+    int size3 = size2 - period + 1;
+    ema.calculate(ema2, ema3, size3);
+
+    int valid = size - 3 * period + 3;
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(valid);
+    temaKernel<<<grid, block>>>(ema1, ema2, ema3, output, period, valid);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    cudaFree(ema1);
+    cudaFree(ema2);
+    cudaFree(ema3);
+}

--- a/tests/cpp/test_basic.cpp
+++ b/tests/cpp/test_basic.cpp
@@ -49,6 +49,35 @@ std::vector<float> dema_ref(const std::vector<float>& in, int period) {
   return out;
 }
 
+std::vector<float> tema_ref(const std::vector<float>& in, int period) {
+  std::ostringstream cmd;
+  cmd << "python3 - <<'PY'\n";
+  cmd << "import numpy as np\n";
+  cmd << "try:\n import talib\nexcept Exception:\n import subprocess, sys\n subprocess.check_call([sys.executable,'-m','pip','install','-q','TA-Lib'])\n import talib\n";
+  cmd << "x=np.array([";
+  for (size_t i = 0; i < in.size(); ++i) {
+    if (i) cmd << ',';
+    cmd << in[i];
+  }
+  cmd << "],dtype=float)\n";
+  cmd << "res=talib.TEMA(x,timeperiod=" << period << ")\n";
+  cmd << "lb=" << 3*(period-1) << "\n";
+  cmd << "out=np.full_like(x,float('nan'))\n";
+  cmd << "out[:len(x)-lb]=res[lb:]\n";
+  cmd << "print('\\n'.join(str(v) for v in out))\n";
+  cmd << "PY";
+  FILE* pipe = popen(cmd.str().c_str(), "r");
+  std::vector<float> out(in.size(), std::numeric_limits<float>::quiet_NaN());
+  if (pipe) {
+    char buf[128];
+    for (size_t i = 0; i < out.size() && fgets(buf, sizeof(buf), pipe); ++i) {
+      out[i] = std::strtof(buf, nullptr);
+    }
+    pclose(pipe);
+  }
+  return out;
+}
+
 std::vector<float> sar_ref(const std::vector<float> &high,
                            const std::vector<float> &low,
                            float step, float maxAcc) {
@@ -189,6 +218,25 @@ TEST(Tacuda, DEMA) {
   auto ref = dema_ref(x, p);
   expect_approx_equal(out, ref);
   for (int i = N - 2 * p + 2; i < N; ++i) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at tail " << i;
+  }
+}
+
+TEST(Tacuda, TEMA) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+
+  std::vector<float> out(N, 0.0f);
+
+  int p = 5;
+  ctStatus_t rc = ct_tema(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_tema failed";
+
+  auto ref = tema_ref(x, p);
+  expect_approx_equal(out, ref);
+  for (int i = N - 3 * p + 3; i < N; ++i) {
     EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at tail " << i;
   }
 }


### PR DESCRIPTION
## Summary
- add TEMA indicator and CUDA kernel combining triple EMA
- expose `ct_tema` through public C API and build system
- add TA-Lib parity tests for TEMA

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68a836e4c1648329ae15b6b44ed5fc1f