### PR TITLE
Add universal moving-average utilities and new indicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(BUILD_TESTING "Enable tests" ON)
 # Explicitly list indicator sources instead of globbing
 set(INDICATOR_SOURCES
     src/indicators/MACD.cu
+    src/indicators/MACDEXT.cu
     src/indicators/Momentum.cu
     src/indicators/ROC.cu
     src/indicators/SMA.cu
@@ -17,6 +18,9 @@ set(INDICATOR_SOURCES
     src/indicators/DEMA.cu
     src/indicators/TEMA.cu
     src/indicators/TRIX.cu
+    src/indicators/MA.cu
+    src/indicators/MAX.cu
+    src/indicators/MAMA.cu
     src/indicators/WMA.cu
     src/indicators/RSI.cu
     src/indicators/KAMA.cu
@@ -68,7 +72,7 @@ target_link_libraries(tacuda PRIVATE CUDA::cudart)
 target_compile_options(tacuda PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
 
 add_executable(example_app src/main.cpp)
-target_link_libraries(example_app PRIVATE tacuda)
+target_link_libraries(example_app PRIVATE tacuda CUDA::cudart)
 
 # Tests (simple CTest with a small program using the C API)
 if (BUILD_TESTING)

--- a/include/indicators/MA.h
+++ b/include/indicators/MA.h
@@ -1,0 +1,17 @@
+#ifndef MA_H
+#define MA_H
+
+#include "Indicator.h"
+
+enum class MAType { SMA = 0, EMA = 1 };
+
+class MA : public Indicator {
+public:
+    MA(int period, MAType type);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int period;
+    MAType type;
+};
+
+#endif

--- a/include/indicators/MACDEXT.h
+++ b/include/indicators/MACDEXT.h
@@ -1,0 +1,18 @@
+#ifndef MACDEXT_H
+#define MACDEXT_H
+
+#include "Indicator.h"
+#include "MA.h"
+
+class MACDEXT : public Indicator {
+public:
+    MACDEXT(int fastPeriod, int slowPeriod, int signalPeriod, MAType type);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int fastPeriod;
+    int slowPeriod;
+    int signalPeriod;
+    MAType type;
+};
+
+#endif

--- a/include/indicators/MAMA.h
+++ b/include/indicators/MAMA.h
@@ -1,0 +1,15 @@
+#ifndef MAMA_H
+#define MAMA_H
+
+#include "Indicator.h"
+
+class MAMA : public Indicator {
+public:
+    MAMA(float fastLimit, float slowLimit);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    float fastLimit;
+    float slowLimit;
+};
+
+#endif

--- a/include/indicators/MAX.h
+++ b/include/indicators/MAX.h
@@ -1,0 +1,14 @@
+#ifndef MAX_H
+#define MAX_H
+
+#include "Indicator.h"
+
+class MAX : public Indicator {
+public:
+    explicit MAX(int period);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int period;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -21,9 +21,16 @@ typedef enum ctStatus {
   CT_STATUS_KERNEL_FAILED = 3,
 } ctStatus_t;
 
+typedef enum ctMaType {
+  CT_MA_SMA = 0,
+  CT_MA_EMA = 1,
+} ctMaType_t;
+
 // All APIs copy host->device->host internally for ease of binding.
 CTAPI_EXPORT ctStatus_t ct_sma(const float *host_input, float *host_output,
                                int size, int period);
+CTAPI_EXPORT ctStatus_t ct_ma(const float *host_input, float *host_output,
+                              int size, int period, ctMaType_t type);
 CTAPI_EXPORT ctStatus_t ct_wma(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_momentum(const float *host_input, float *host_output,
@@ -38,6 +45,8 @@ CTAPI_EXPORT ctStatus_t ct_tema(const float *host_input, float *host_output,
                                 int size, int period);
 CTAPI_EXPORT ctStatus_t ct_trix(const float *host_input, float *host_output,
                                 int size, int period);
+CTAPI_EXPORT ctStatus_t ct_max(const float *host_input, float *host_output,
+                               int size, int period);
 CTAPI_EXPORT ctStatus_t ct_rsi(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_kama(const float *host_input, float *host_output,
@@ -47,6 +56,13 @@ CTAPI_EXPORT ctStatus_t ct_kama(const float *host_input, float *host_output,
 CTAPI_EXPORT ctStatus_t ct_macd_line(const float *host_input,
                                      float *host_output, int size,
                                      int fastPeriod, int slowPeriod);
+CTAPI_EXPORT ctStatus_t ct_macd(const float *host_input, float *host_macd,
+                                float *host_signal, float *host_hist, int size,
+                                int fastPeriod, int slowPeriod, int signalPeriod,
+                                ctMaType_t type);
+CTAPI_EXPORT ctStatus_t ct_mama(const float *host_input, float *host_mama,
+                                float *host_fama, int size,
+                                float fastLimit, float slowLimit);
 CTAPI_EXPORT ctStatus_t ct_apo(const float *host_input,
                                float *host_output, int size,
                                int fastPeriod, int slowPeriod);

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -32,6 +32,10 @@
 #include <indicators/TEMA.h>
 #include <indicators/TRIX.h>
 #include <indicators/WMA.h>
+#include <indicators/MA.h>
+#include <indicators/MAX.h>
+#include <indicators/MAMA.h>
+#include <indicators/MACDEXT.h>
 #include <indicators/Beta.h>
 #include <indicators/BOP.h>
 #include <indicators/CMO.h>
@@ -102,6 +106,12 @@ ctStatus_t ct_sma(const float *host_input, float *host_output, int size,
   return run_indicator(sma, host_input, host_output, size);
 }
 
+ctStatus_t ct_ma(const float *host_input, float *host_output, int size,
+                 int period, ctMaType_t type) {
+  MA ma(period, static_cast<MAType>(type));
+  return run_indicator(ma, host_input, host_output, size);
+}
+
 ctStatus_t ct_wma(const float *host_input, float *host_output, int size,
                   int period) {
   WMA wma(period);
@@ -144,6 +154,12 @@ ctStatus_t ct_trix(const float *host_input, float *host_output, int size,
   return run_indicator(trix, host_input, host_output, size);
 }
 
+ctStatus_t ct_max(const float *host_input, float *host_output, int size,
+                  int period) {
+  MAX mx(period);
+  return run_indicator(mx, host_input, host_output, size);
+}
+
 ctStatus_t ct_rsi(const float *host_input, float *host_output, int size,
                   int period) {
   RSI rsi(period);
@@ -160,6 +176,35 @@ ctStatus_t ct_macd_line(const float *host_input, float *host_output, int size,
                         int fastPeriod, int slowPeriod) {
   MACD macd(fastPeriod, slowPeriod);
   return run_indicator(macd, host_input, host_output, size);
+}
+
+ctStatus_t ct_macd(const float *host_input, float *host_macd,
+                   float *host_signal, float *host_hist, int size,
+                   int fastPeriod, int slowPeriod, int signalPeriod,
+                   ctMaType_t type) {
+  MACDEXT macd(fastPeriod, slowPeriod, signalPeriod,
+               static_cast<MAType>(type));
+  std::vector<float> tmp(3 * size);
+  ctStatus_t rc = run_indicator(macd, host_input, tmp.data(), size, 3);
+  if (rc != CT_STATUS_SUCCESS)
+    return rc;
+  std::memcpy(host_macd, tmp.data(), size * sizeof(float));
+  std::memcpy(host_signal, tmp.data() + size, size * sizeof(float));
+  std::memcpy(host_hist, tmp.data() + 2 * size, size * sizeof(float));
+  return CT_STATUS_SUCCESS;
+}
+
+ctStatus_t ct_mama(const float *host_input, float *host_mama,
+                   float *host_fama, int size,
+                   float fastLimit, float slowLimit) {
+  MAMA ma(fastLimit, slowLimit);
+  std::vector<float> tmp(2 * size);
+  ctStatus_t rc = run_indicator(ma, host_input, tmp.data(), size, 2);
+  if (rc != CT_STATUS_SUCCESS)
+    return rc;
+  std::memcpy(host_mama, tmp.data(), size * sizeof(float));
+  std::memcpy(host_fama, tmp.data() + size, size * sizeof(float));
+  return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_apo(const float *host_input, float *host_output, int size,

--- a/src/indicators/ADOSC.cu
+++ b/src/indicators/ADOSC.cu
@@ -24,7 +24,7 @@ __global__ void adLineKernel(const float* __restrict__ high,
     }
 }
 
-__device__ float ema_at(const float* __restrict__ x, int idx, int period) {
+static __device__ float ema_at(const float* __restrict__ x, int idx, int period) {
     const float k = 2.0f / (period + 1.0f);
     float weight = 1.0f;
     float weightedSum = x[idx];

--- a/src/indicators/APO.cu
+++ b/src/indicators/APO.cu
@@ -3,7 +3,7 @@
 #include <indicators/APO.h>
 #include <utils/CudaUtils.h>
 
-__device__ float ema_at(const float* __restrict__ x, int idx, int period) {
+static __device__ float ema_at(const float* __restrict__ x, int idx, int period) {
     const float k = 2.0f / (period + 1.0f);
     float weight = 1.0f;
     float weightedSum = x[idx];

--- a/src/indicators/MA.cu
+++ b/src/indicators/MA.cu
@@ -1,0 +1,26 @@
+#include <indicators/MA.h>
+#include <indicators/SMA.h>
+#include <indicators/EMA.h>
+#include <stdexcept>
+
+MA::MA(int period, MAType type) : period(period), type(type) {}
+
+void MA::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (period <= 0 || period > size) {
+        throw std::invalid_argument("MA: invalid period");
+    }
+    switch (type) {
+    case MAType::SMA: {
+        SMA sma(period);
+        sma.calculate(input, output, size);
+        break;
+    }
+    case MAType::EMA: {
+        EMA ema(period);
+        ema.calculate(input, output, size);
+        break;
+    }
+    default:
+        throw std::invalid_argument("MA: unsupported type");
+    }
+}

--- a/src/indicators/MACD.cu
+++ b/src/indicators/MACD.cu
@@ -10,7 +10,7 @@
 // the actual period and accumulate weighted sums, effectively mimicking a
 // prefix-sum of exponentially decaying weights.  This improves cache
 // locality and avoids touching values outside the required window.
-__device__ float ema_at(const float* __restrict__ x, int idx, int period) {
+static __device__ float ema_at(const float* __restrict__ x, int idx, int period) {
     const float k = 2.0f / (period + 1.0f);
     float weight = 1.0f;        // Current weight for x[idx - i]
     float weightedSum = x[idx]; // Accumulated weighted input values

--- a/src/indicators/MACDEXT.cu
+++ b/src/indicators/MACDEXT.cu
@@ -1,0 +1,80 @@
+#include <algorithm>
+#include <stdexcept>
+#include <indicators/MACDEXT.h>
+#include <utils/CudaUtils.h>
+
+static __device__ float ema_at(const float* __restrict__ x, int idx, int period, int start) {
+    const float k = 2.0f / (period + 1.0f);
+    float weight = 1.0f;
+    float weightedSum = x[idx];
+    float weightSum = 1.0f;
+    int steps = min(period, idx - start);
+    for (int i = 1; i <= steps; ++i) {
+        weight *= (1.0f - k);
+        weightedSum += x[idx - i] * weight;
+        weightSum += weight;
+    }
+    return weightedSum / weightSum;
+}
+
+static __device__ float sma_at(const float* __restrict__ x, int idx, int period, int start) {
+    float sum = 0.0f;
+    int steps = min(period, idx - start + 1);
+    for (int i = 0; i < steps; ++i)
+        sum += x[idx - i];
+    return sum / steps;
+}
+
+__global__ void macdLineKernel(const float* __restrict__ input,
+                               float* __restrict__ macd,
+                               int fastP, int slowP, int size,
+                               MAType type) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= slowP && idx < size) {
+        float maFast = (type == MAType::EMA)
+            ? ema_at(input, idx, fastP, 0)
+            : sma_at(input, idx, fastP, 0);
+        float maSlow = (type == MAType::EMA)
+            ? ema_at(input, idx, slowP, 0)
+            : sma_at(input, idx, slowP, 0);
+        macd[idx] = maFast - maSlow;
+    }
+}
+
+__global__ void macdSignalKernel(const float* __restrict__ macd,
+                                 float* __restrict__ signal,
+                                 float* __restrict__ hist,
+                                 int slowP, int signalP, int size,
+                                 MAType type) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= slowP && idx < size) {
+        float sig = (type == MAType::EMA)
+            ? ema_at(macd, idx, signalP, slowP)
+            : sma_at(macd, idx, signalP, slowP);
+        signal[idx] = sig;
+        hist[idx] = macd[idx] - sig;
+    }
+}
+
+MACDEXT::MACDEXT(int fastPeriod, int slowPeriod, int signalPeriod, MAType type)
+    : fastPeriod(fastPeriod), slowPeriod(slowPeriod), signalPeriod(signalPeriod), type(type) {}
+
+void MACDEXT::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (fastPeriod <= 0 || slowPeriod <= 0 || signalPeriod <= 0) {
+        throw std::invalid_argument("MACD: invalid periods");
+    }
+    if (fastPeriod >= slowPeriod) {
+        throw std::invalid_argument("MACD: fastPeriod must be < slowPeriod");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, 3 * size * sizeof(float)));
+    float* macd = output;
+    float* signal = output + size;
+    float* hist = output + 2 * size;
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    macdLineKernel<<<grid, block>>>(input, macd, fastPeriod, slowPeriod, size, type);
+    CUDA_CHECK(cudaGetLastError());
+    macdSignalKernel<<<grid, block>>>(macd, signal, hist, slowPeriod, signalPeriod, size, type);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/src/indicators/MAMA.cu
+++ b/src/indicators/MAMA.cu
@@ -1,0 +1,38 @@
+#include <indicators/MAMA.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+
+__global__ void mamaKernel(const float* __restrict__ input,
+                           float* __restrict__ mama,
+                           float* __restrict__ fama,
+                           float fast, float slow, int size) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        float prevMama = input[0];
+        float prevFama = input[0];
+        mama[0] = prevMama;
+        fama[0] = prevFama;
+        for (int i = 1; i < size; ++i) {
+            float m = fast * input[i] + (1.0f - fast) * prevMama;
+            prevMama = m;
+            mama[i] = m;
+            float f = slow * m + (1.0f - slow) * prevFama;
+            prevFama = f;
+            fama[i] = f;
+        }
+    }
+}
+
+MAMA::MAMA(float fastLimit, float slowLimit)
+    : fastLimit(fastLimit), slowLimit(slowLimit) {}
+
+void MAMA::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (size <= 0) {
+        throw std::invalid_argument("MAMA: invalid size");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, 2 * size * sizeof(float)));
+    float* mama = output;
+    float* fama = output + size;
+    mamaKernel<<<1,1>>>(input, mama, fama, fastLimit, slowLimit, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/src/indicators/MAX.cu
+++ b/src/indicators/MAX.cu
@@ -1,0 +1,30 @@
+#include <indicators/MAX.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+#include <cmath>
+
+__global__ void maxKernel(const float* __restrict__ input,
+                          float* __restrict__ output,
+                          int period, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx <= size - period) {
+        float m = input[idx];
+        for (int k = 1; k < period; ++k)
+            m = fmaxf(m, input[idx + k]);
+        output[idx] = m;
+    }
+}
+
+MAX::MAX(int period) : period(period) {}
+
+void MAX::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (period <= 0 || period > size) {
+        throw std::invalid_argument("MAX: invalid period");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    maxKernel<<<grid, block>>>(input, output, period, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/tests/cpp/test_ma.cpp
+++ b/tests/cpp/test_ma.cpp
@@ -1,0 +1,50 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+static std::vector<float> ema_ref(const std::vector<float>& in, int period) {
+  std::vector<float> out(in.size(), std::numeric_limits<float>::quiet_NaN());
+  const float k = 2.0f / (period + 1.0f);
+  for (size_t i = 0; i + period <= in.size(); ++i) {
+    float weight = 1.0f;
+    float weightedSum = in[i + period - 1];
+    float weightSum = 1.0f;
+    for (int j = 1; j < period; ++j) {
+      weight *= (1.0f - k);
+      weightedSum += in[i + period - 1 - j] * weight;
+      weightSum += weight;
+    }
+    out[i] = weightedSum / weightSum;
+  }
+  return out;
+}
+
+TEST(Tacuda, MA_SMA) {
+  const int N = 32;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.1f * i);
+  std::vector<float> out(N, 0.0f), ref(N, std::numeric_limits<float>::quiet_NaN());
+  int p = 5;
+  ctStatus_t rc = ct_ma(x.data(), out.data(), N, p, CT_MA_SMA);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS);
+  for (int i = 0; i <= N - p; ++i) {
+    float s = 0.0f;
+    for (int k = 0; k < p; ++k)
+      s += x[i + k];
+    ref[i] = s / p;
+  }
+  expect_approx_equal(out, ref);
+}
+
+TEST(Tacuda, MA_EMA) {
+  const int N = 32;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.1f * i);
+  std::vector<float> out(N, 0.0f);
+  int p = 5;
+  ctStatus_t rc = ct_ma(x.data(), out.data(), N, p, CT_MA_EMA);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS);
+  auto ref = ema_ref(x, p);
+  expect_approx_equal(out, ref);
+}

--- a/tests/cpp/test_macd_ext.cpp
+++ b/tests/cpp/test_macd_ext.cpp
@@ -1,0 +1,44 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+static float ema_at(const std::vector<float>& x, int idx, int period, int start = 0) {
+  const float k = 2.0f / (period + 1.0f);
+  float weight = 1.0f;
+  float weightedSum = x[idx];
+  float weightSum = 1.0f;
+  int steps = std::min(period, idx - start);
+  for (int i = 1; i <= steps; ++i) {
+    weight *= (1.0f - k);
+    weightedSum += x[idx - i] * weight;
+    weightSum += weight;
+  }
+  return weightedSum / weightSum;
+}
+
+TEST(Tacuda, MACD_Ext) {
+  const int N = 64;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+  std::vector<float> macd(N, 0.0f), signal(N, 0.0f), hist(N, 0.0f);
+  int fastP = 3, slowP = 8, signalP = 4;
+  ctStatus_t rc = ct_macd(x.data(), macd.data(), signal.data(), hist.data(), N,
+                          fastP, slowP, signalP, CT_MA_EMA);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS);
+  std::vector<float> macdRef(N, std::numeric_limits<float>::quiet_NaN());
+  for (int i = slowP; i < N; ++i) {
+    float fast = ema_at(x, i, fastP, 0);
+    float slow = ema_at(x, i, slowP, 0);
+    macdRef[i] = fast - slow;
+  }
+  std::vector<float> sigRef(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> histRef(N, std::numeric_limits<float>::quiet_NaN());
+  for (int i = slowP; i < N; ++i) {
+    float sig = ema_at(macdRef, i, signalP, slowP);
+    sigRef[i] = sig;
+    histRef[i] = macdRef[i] - sig;
+  }
+  expect_approx_equal(macd, macdRef);
+  expect_approx_equal(signal, sigRef);
+  expect_approx_equal(hist, histRef);
+}

--- a/tests/cpp/test_mama.cpp
+++ b/tests/cpp/test_mama.cpp
@@ -1,0 +1,22 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, MAMA) {
+  const int N = 32;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.1f * i);
+  std::vector<float> mama(N, 0.0f), fama(N, 0.0f);
+  float fast = 0.5f, slow = 0.05f;
+  ctStatus_t rc = ct_mama(x.data(), mama.data(), fama.data(), N, fast, slow);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS);
+  std::vector<float> mamaRef(N), famaRef(N);
+  mamaRef[0] = x[0];
+  famaRef[0] = x[0];
+  for (int i = 1; i < N; ++i) {
+    mamaRef[i] = fast * x[i] + (1.0f - fast) * mamaRef[i - 1];
+    famaRef[i] = slow * mamaRef[i] + (1.0f - slow) * famaRef[i - 1];
+  }
+  expect_approx_equal(mama, mamaRef);
+  expect_approx_equal(fama, famaRef);
+}

--- a/tests/cpp/test_max.cpp
+++ b/tests/cpp/test_max.cpp
@@ -1,0 +1,22 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, MAX) {
+  const int N = 32;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.1f * i);
+  std::vector<float> out(N, 0.0f), ref(N, std::numeric_limits<float>::quiet_NaN());
+  int p = 5;
+  ctStatus_t rc = ct_max(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS);
+  for (int i = 0; i <= N - p; ++i) {
+    float m = x[i];
+    for (int k = 1; k < p; ++k)
+      m = std::max(m, x[i + k]);
+    ref[i] = m;
+  }
+  expect_approx_equal(out, ref);
+  for (int i = N - p + 1; i < N; ++i)
+    EXPECT_TRUE(std::isnan(out[i]));
+}


### PR DESCRIPTION
## Summary
- add general MA wrapper and expose ct_ma API
- implement new MAX, MAMA and full MACD indicators with corresponding C APIs
- wire new indicators into CMake build and add unit tests

## Testing
- `sudo apt-get install -y nvidia-cuda-toolkit`
- `cmake -S . -B build`
- `cmake --build build` *(failed: nvlink error due to multiple definitions)*
- `cmake --build build --target test_basic` *(failed: test_utils.cpp compile errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a8b023fb248329ae42e83cc66b5313