### PR TITLE
Add NATR, PPO, and PVO indicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ set(INDICATOR_SOURCES
     src/indicators/LINEARREG_ANGLE.cu
     src/indicators/LINEARREG_INTERCEPT.cu
     src/indicators/LINEARREG_SLOPE.cu
+    src/indicators/NATR.cu
+    src/indicators/PPO.cu
+    src/indicators/PVO.cu
 )
 
 add_library(tacuda SHARED

--- a/include/indicators/NATR.h
+++ b/include/indicators/NATR.h
@@ -1,0 +1,18 @@
+#ifndef NATR_H
+#define NATR_H
+
+#include "Indicator.h"
+
+class NATR : public Indicator {
+public:
+  explicit NATR(int period);
+  void calculate(const float *high, const float *low, const float *close,
+                 float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+
+private:
+  int period;
+};
+
+#endif

--- a/include/indicators/PPO.h
+++ b/include/indicators/PPO.h
@@ -1,0 +1,17 @@
+#ifndef PPO_H
+#define PPO_H
+
+#include "Indicator.h"
+
+class PPO : public Indicator {
+public:
+  PPO(int fastPeriod, int slowPeriod);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+
+private:
+  int fastPeriod;
+  int slowPeriod;
+};
+
+#endif

--- a/include/indicators/PVO.h
+++ b/include/indicators/PVO.h
@@ -1,0 +1,17 @@
+#ifndef PVO_H
+#define PVO_H
+
+#include "Indicator.h"
+
+class PVO : public Indicator {
+public:
+  PVO(int fastPeriod, int slowPeriod);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+
+private:
+  int fastPeriod;
+  int slowPeriod;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -67,6 +67,10 @@ CTAPI_EXPORT ctStatus_t ct_mama(const float *host_input, float *host_mama,
                                 float slowLimit);
 CTAPI_EXPORT ctStatus_t ct_apo(const float *host_input, float *host_output,
                                int size, int fastPeriod, int slowPeriod);
+CTAPI_EXPORT ctStatus_t ct_ppo(const float *host_input, float *host_output,
+                               int size, int fastPeriod, int slowPeriod);
+CTAPI_EXPORT ctStatus_t ct_pvo(const float *host_volume, float *host_output,
+                               int size, int fastPeriod, int slowPeriod);
 CTAPI_EXPORT ctStatus_t ct_bbands(const float *host_input, float *host_upper,
                                   float *host_middle, float *host_lower,
                                   int size, int period, float upperMul,
@@ -74,6 +78,9 @@ CTAPI_EXPORT ctStatus_t ct_bbands(const float *host_input, float *host_upper,
 CTAPI_EXPORT ctStatus_t ct_atr(const float *host_high, const float *host_low,
                                const float *host_close, float *host_output,
                                int size, int period, float initial);
+CTAPI_EXPORT ctStatus_t ct_natr(const float *host_high, const float *host_low,
+                                const float *host_close, float *host_output,
+                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_stochastic(const float *host_high,
                                       const float *host_low,
                                       const float *host_close, float *host_k,

--- a/src/indicators/NATR.cu
+++ b/src/indicators/NATR.cu
@@ -1,0 +1,54 @@
+#include <indicators/NATR.h>
+#include <math.h>
+#include <stdexcept>
+#include <utils/CudaUtils.h>
+
+__global__ void natrKernel(const float *__restrict__ high,
+                           const float *__restrict__ low,
+                           const float *__restrict__ close,
+                           float *__restrict__ output, int period, int size) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    float prevClose = close[0];
+    float sum = 0.0f;
+    for (int i = 0; i < period; ++i) {
+      float tr = fmaxf(high[i] - low[i],
+                       fmaxf(fabsf(high[i] - prevClose),
+                             fabsf(low[i] - prevClose)));
+      sum += tr;
+      prevClose = close[i];
+    }
+    float atr = sum / period;
+    output[period - 1] = close[period - 1] == 0.0f
+                             ? 0.0f
+                             : 100.0f * atr / close[period - 1];
+    for (int i = period; i < size; ++i) {
+      float tr = fmaxf(high[i] - low[i],
+                       fmaxf(fabsf(high[i] - prevClose),
+                             fabsf(low[i] - prevClose)));
+      atr = (atr * (period - 1) + tr) / period;
+      output[i] = close[i] == 0.0f ? 0.0f : 100.0f * atr / close[i];
+      prevClose = close[i];
+    }
+  }
+}
+
+NATR::NATR(int period) : period(period) {}
+
+void NATR::calculate(const float *high, const float *low, const float *close,
+                     float *output, int size) noexcept(false) {
+  if (period <= 0 || period > size) {
+    throw std::invalid_argument("NATR: invalid period");
+  }
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  natrKernel<<<1, 1>>>(high, low, close, output, period, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void NATR::calculate(const float *input, float *output,
+                     int size) noexcept(false) {
+  const float *high = input;
+  const float *low = input + size;
+  const float *close = input + 2 * size;
+  calculate(high, low, close, output, size);
+}

--- a/src/indicators/PPO.cu
+++ b/src/indicators/PPO.cu
@@ -1,0 +1,49 @@
+#include <algorithm>
+#include <stdexcept>
+#include <indicators/PPO.h>
+#include <utils/CudaUtils.h>
+
+static __device__ float ema_at(const float* __restrict__ x, int idx, int period) {
+  const float k = 2.0f / (period + 1.0f);
+  float weight = 1.0f;
+  float weightedSum = x[idx];
+  float weightSum = 1.0f;
+  int steps = min(period, idx);
+#pragma unroll
+  for (int i = 1; i <= steps; ++i) {
+    weight *= (1.0f - k);
+    weightedSum += x[idx - i] * weight;
+    weightSum += weight;
+  }
+  return weightedSum / weightSum;
+}
+
+__global__ void ppoKernel(const float* __restrict__ input,
+                          float* __restrict__ output,
+                          int fastP, int slowP, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= slowP && idx < size) {
+    float emaFast = ema_at(input, idx, fastP);
+    float emaSlow = ema_at(input, idx, slowP);
+    output[idx] = emaSlow == 0.0f ? 0.0f : 100.0f * (emaFast - emaSlow) / emaSlow;
+  }
+}
+
+PPO::PPO(int fastPeriod, int slowPeriod)
+    : fastPeriod(fastPeriod), slowPeriod(slowPeriod) {}
+
+void PPO::calculate(const float* input, float* output,
+                    int size) noexcept(false) {
+  if (fastPeriod <= 0 || slowPeriod <= 0) {
+    throw std::invalid_argument("PPO: invalid periods");
+  }
+  if (fastPeriod >= slowPeriod) {
+    throw std::invalid_argument("PPO: fastPeriod must be < slowPeriod");
+  }
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  ppoKernel<<<grid, block>>>(input, output, fastPeriod, slowPeriod, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/src/indicators/PVO.cu
+++ b/src/indicators/PVO.cu
@@ -1,0 +1,49 @@
+#include <algorithm>
+#include <stdexcept>
+#include <indicators/PVO.h>
+#include <utils/CudaUtils.h>
+
+static __device__ float ema_at(const float* __restrict__ x, int idx, int period) {
+  const float k = 2.0f / (period + 1.0f);
+  float weight = 1.0f;
+  float weightedSum = x[idx];
+  float weightSum = 1.0f;
+  int steps = min(period, idx);
+#pragma unroll
+  for (int i = 1; i <= steps; ++i) {
+    weight *= (1.0f - k);
+    weightedSum += x[idx - i] * weight;
+    weightSum += weight;
+  }
+  return weightedSum / weightSum;
+}
+
+__global__ void pvoKernel(const float* __restrict__ input,
+                          float* __restrict__ output,
+                          int fastP, int slowP, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= slowP && idx < size) {
+    float emaFast = ema_at(input, idx, fastP);
+    float emaSlow = ema_at(input, idx, slowP);
+    output[idx] = emaSlow == 0.0f ? 0.0f : 100.0f * (emaFast - emaSlow) / emaSlow;
+  }
+}
+
+PVO::PVO(int fastPeriod, int slowPeriod)
+    : fastPeriod(fastPeriod), slowPeriod(slowPeriod) {}
+
+void PVO::calculate(const float* input, float* output,
+                    int size) noexcept(false) {
+  if (fastPeriod <= 0 || slowPeriod <= 0) {
+    throw std::invalid_argument("PVO: invalid periods");
+  }
+  if (fastPeriod >= slowPeriod) {
+    throw std::invalid_argument("PVO: fastPeriod must be < slowPeriod");
+  }
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  pvoKernel<<<grid, block>>>(input, output, fastPeriod, slowPeriod, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/tests/cpp/test_natr.cpp
+++ b/tests/cpp/test_natr.cpp
@@ -1,0 +1,45 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, NATR) {
+  std::vector<float> high = {48.70f, 48.72f, 48.90f, 48.87f, 48.82f,
+                             49.05f, 49.20f, 49.35f, 49.92f, 50.19f,
+                             50.12f, 49.66f, 49.88f, 50.19f, 50.36f};
+  std::vector<float> low = {47.79f, 48.14f, 48.39f, 48.37f, 48.24f,
+                            48.64f, 48.94f, 48.86f, 49.50f, 49.87f,
+                            49.20f, 48.90f, 49.43f, 49.73f, 49.26f};
+  std::vector<float> close = {48.16f, 48.61f, 48.75f, 48.63f, 48.74f,
+                              49.03f, 49.07f, 49.32f, 49.91f, 49.91f,
+                              49.40f, 49.50f, 49.75f, 49.87f, 50.13f};
+  const int N = high.size();
+  std::vector<float> out(N, 0.0f),
+      ref(N, std::numeric_limits<float>::quiet_NaN());
+
+  int p = 14;
+  ctStatus_t rc =
+      ct_natr(high.data(), low.data(), close.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_natr failed";
+
+  std::vector<float> tr(N);
+  tr[0] = high[0] - low[0];
+  for (int i = 1; i < N; ++i) {
+    float range1 = high[i] - low[i];
+    float range2 = std::fabs(high[i] - close[i - 1]);
+    float range3 = std::fabs(low[i] - close[i - 1]);
+    tr[i] = std::max(range1, std::max(range2, range3));
+  }
+  float sum = 0.0f;
+  for (int i = 0; i < p; ++i)
+    sum += tr[i];
+  float atr = sum / p;
+  ref[p - 1] = 100.0f * atr / close[p - 1];
+  for (int i = p; i < N; ++i) {
+    atr = (atr * (p - 1) + tr[i]) / p;
+    ref[i] = 100.0f * atr / close[i];
+  }
+
+  expect_approx_equal(out, ref);
+  for (int i = 0; i < p - 1; ++i) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
+  }
+}

--- a/tests/cpp/test_ppo.cpp
+++ b/tests/cpp/test_ppo.cpp
@@ -1,0 +1,17 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, PPO) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+  std::vector<float> out(N, 0.0f);
+  int fastP = 12, slowP = 26;
+  ctStatus_t rc = ct_ppo(x.data(), out.data(), N, fastP, slowP);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_ppo failed";
+  auto ref = ppo_ref(x, fastP, slowP);
+  expect_approx_equal(out, ref);
+  for (int i = 0; i < slowP; ++i)
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
+}

--- a/tests/cpp/test_pvo.cpp
+++ b/tests/cpp/test_pvo.cpp
@@ -1,0 +1,17 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, PVO) {
+  const int N = 128;
+  std::vector<float> v(N);
+  for (int i = 0; i < N; ++i)
+    v[i] = 100.0f + std::sin(0.1f * i);
+  std::vector<float> out(N, 0.0f);
+  int fastP = 12, slowP = 26;
+  ctStatus_t rc = ct_pvo(v.data(), out.data(), N, fastP, slowP);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_pvo failed";
+  auto ref = pvo_ref(v, fastP, slowP);
+  expect_approx_equal(out, ref);
+  for (int i = 0; i < slowP; ++i)
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
+}

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -460,6 +460,24 @@ std::vector<float> sar_ref(const std::vector<float> &high,
           return out;
         }
 
+        std::vector<float> ppo_ref(const std::vector<float> &in, int fastP,
+                                   int slowP) {
+          int N = in.size();
+          std::vector<float> out(N, std::numeric_limits<float>::quiet_NaN());
+          for (int i = slowP; i < N; ++i) {
+            float emaFast = ema_at_ref(in, i, fastP);
+            float emaSlow = ema_at_ref(in, i, slowP);
+            out[i] = (emaSlow == 0.0f) ? 0.0f
+                                       : 100.0f * (emaFast - emaSlow) / emaSlow;
+          }
+          return out;
+        }
+
+        std::vector<float> pvo_ref(const std::vector<float> &in, int fastP,
+                                   int slowP) {
+          return ppo_ref(in, fastP, slowP);
+        }
+
         std::vector<float> aroonosc_ref(const std::vector<float> &high,
                                         const std::vector<float> &low,
                                         int period) {

--- a/tests/cpp/test_utils.hpp
+++ b/tests/cpp/test_utils.hpp
@@ -38,6 +38,8 @@ std::vector<float> ad_ref(const std::vector<float>& high,
                           const std::vector<float>& close,
                           const std::vector<float>& volume);
 std::vector<float> apo_ref(const std::vector<float>& in, int fastP, int slowP);
+std::vector<float> ppo_ref(const std::vector<float>& in, int fastP, int slowP);
+std::vector<float> pvo_ref(const std::vector<float>& in, int fastP, int slowP);
 std::vector<float> aroonosc_ref(const std::vector<float>& high,
                                 const std::vector<float>& low,
                                 int period);


### PR DESCRIPTION
## Summary
- add normalized average true range (NATR)
- implement percentage price/volume oscillators (PPO/PVO)
- expose new indicators through C API and tests

## Testing
- `cmake -S . -B build` *(fails: target_compile_features no known features for CXX compiler)*


------
https://chatgpt.com/codex/tasks/task_e_68a8c567641883299544e2418e4f5273