### PR TITLE
Implement price change, extended SAR, stddev, and fast stochastic indicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ set(INDICATOR_SOURCES
     src/indicators/DEMA.cu
     src/indicators/TEMA.cu
     src/indicators/TRIX.cu
+    src/indicators/Change.cu
+    src/indicators/StdDev.cu
     src/indicators/MA.cu
     src/indicators/MAX.cu
     src/indicators/MAMA.cu
@@ -42,6 +44,8 @@ set(INDICATOR_SOURCES
     src/indicators/AvgPrice.cu
     src/indicators/MIN.cu
     src/indicators/MedPrice.cu
+    src/indicators/SAREXT.cu
+    src/indicators/StochasticFast.cu
     src/indicators/Beta.cu
     src/indicators/BOP.cu
     src/indicators/CMO.cu

--- a/include/indicators/Change.h
+++ b/include/indicators/Change.h
@@ -1,0 +1,14 @@
+#ifndef CHANGE_H
+#define CHANGE_H
+
+#include "Indicator.h"
+
+class Change : public Indicator {
+public:
+    explicit Change(int period);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int period;
+};
+
+#endif

--- a/include/indicators/SAREXT.h
+++ b/include/indicators/SAREXT.h
@@ -1,0 +1,20 @@
+#ifndef SAREXT_H
+#define SAREXT_H
+
+#include "Indicator.h"
+
+class SAREXT : public Indicator {
+public:
+    SAREXT(float startValue, float offsetOnReverse,
+           float accInitLong, float accLong, float accMaxLong,
+           float accInitShort, float accShort, float accMaxShort);
+    void calculate(const float* high, const float* low,
+                   float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    float startValue, offsetOnReverse;
+    float accInitLong, accLong, accMaxLong;
+    float accInitShort, accShort, accMaxShort;
+};
+
+#endif

--- a/include/indicators/StdDev.h
+++ b/include/indicators/StdDev.h
@@ -1,0 +1,14 @@
+#ifndef STDDEV_H
+#define STDDEV_H
+
+#include "Indicator.h"
+
+class StdDev : public Indicator {
+public:
+    explicit StdDev(int period);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int period;
+};
+
+#endif

--- a/include/indicators/StochasticFast.h
+++ b/include/indicators/StochasticFast.h
@@ -1,0 +1,17 @@
+#ifndef STOCHASTIC_FAST_H
+#define STOCHASTIC_FAST_H
+
+#include "Indicator.h"
+
+class StochasticFast : public Indicator {
+public:
+    StochasticFast(int kPeriod, int dPeriod);
+    void calculate(const float* high, const float* low, const float* close,
+                   float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int kPeriod;
+    int dPeriod;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -35,6 +35,8 @@ CTAPI_EXPORT ctStatus_t ct_wma(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_momentum(const float *host_input, float *host_output,
                                     int size, int period);
+CTAPI_EXPORT ctStatus_t ct_change(const float *host_input, float *host_output,
+                                  int size, int period);
 CTAPI_EXPORT ctStatus_t ct_roc(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_ema(const float *host_input, float *host_output,
@@ -49,6 +51,8 @@ CTAPI_EXPORT ctStatus_t ct_max(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_min(const float *host_input, float *host_output,
                                int size, int period);
+CTAPI_EXPORT ctStatus_t ct_stddev(const float *host_input, float *host_output,
+                                  int size, int period);
 CTAPI_EXPORT ctStatus_t ct_rsi(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_kama(const float *host_input, float *host_output,
@@ -86,6 +90,11 @@ CTAPI_EXPORT ctStatus_t ct_stochastic(const float *host_high,
                                       const float *host_close, float *host_k,
                                       float *host_d, int size, int kPeriod,
                                       int dPeriod);
+CTAPI_EXPORT ctStatus_t ct_stochf(const float *host_high,
+                                  const float *host_low,
+                                  const float *host_close, float *host_k,
+                                  float *host_d, int size, int kPeriod,
+                                  int dPeriod);
 CTAPI_EXPORT ctStatus_t ct_cci(const float *host_high, const float *host_low,
                                const float *host_close, float *host_output,
                                int size, int period);
@@ -119,6 +128,12 @@ CTAPI_EXPORT ctStatus_t ct_obv(const float *host_price,
 CTAPI_EXPORT ctStatus_t ct_sar(const float *host_high, const float *host_low,
                                float *host_output, int size, float step,
                                float maxAcceleration);
+CTAPI_EXPORT ctStatus_t ct_sarext(const float *host_high, const float *host_low,
+                                  float *host_output, int size, float startValue,
+                                  float offsetOnReverse, float accInitLong,
+                                  float accLong, float accMaxLong,
+                                  float accInitShort, float accShort,
+                                  float accMaxShort);
 CTAPI_EXPORT ctStatus_t ct_aroon(const float *host_high, const float *host_low,
                                  float *host_up, float *host_down,
                                  float *host_osc, int size, int upPeriod,

--- a/src/indicators/Change.cu
+++ b/src/indicators/Change.cu
@@ -1,0 +1,25 @@
+#include <indicators/Change.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+
+__global__ void changeKernel(const float* __restrict__ input, float* __restrict__ output,
+                             int period, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= period && idx < size) {
+        output[idx] = input[idx] - input[idx - period];
+    }
+}
+
+Change::Change(int period) : period(period) {}
+
+void Change::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (period <= 0 || period >= size) {
+        throw std::invalid_argument("Change: invalid period");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    changeKernel<<<grid, block>>>(input, output, period, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/src/indicators/SAREXT.cu
+++ b/src/indicators/SAREXT.cu
@@ -1,0 +1,79 @@
+#include <indicators/SAREXT.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+#include <math.h>
+
+__global__ void sarextKernel(const float* __restrict__ high,
+                             const float* __restrict__ low,
+                             float* __restrict__ output,
+                             float startValue, float offset,
+                             float accInitLong, float accLong, float accMaxLong,
+                             float accInitShort, float accShort, float accMaxShort,
+                             int size) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        float sar = (startValue != 0.0f) ? startValue : low[0];
+        bool longPos = true;
+        float af = accInitLong;
+        float ep = high[0];
+        output[0] = sar;
+        for (int i = 1; i < size; ++i) {
+            sar = sar + af * (ep - sar);
+            if (longPos) {
+                sar = fminf(sar, low[i - 1]);
+                if (low[i] < sar) {
+                    longPos = false;
+                    sar = ep + offset;
+                    ep = low[i];
+                    af = accInitShort;
+                    sar = fmaxf(sar, high[i - 1]);
+                } else {
+                    if (high[i] > ep) {
+                        ep = high[i];
+                        af = fminf(af + accLong, accMaxLong);
+                    }
+                }
+            } else {
+                sar = fmaxf(sar, high[i - 1]);
+                if (high[i] > sar) {
+                    longPos = true;
+                    sar = ep - offset;
+                    ep = high[i];
+                    af = accInitLong;
+                    sar = fminf(sar, low[i - 1]);
+                } else {
+                    if (low[i] < ep) {
+                        ep = low[i];
+                        af = fminf(af + accShort, accMaxShort);
+                    }
+                }
+            }
+            output[i] = sar;
+        }
+    }
+}
+
+SAREXT::SAREXT(float startValue, float offsetOnReverse,
+               float accInitLong, float accLong, float accMaxLong,
+               float accInitShort, float accShort, float accMaxShort)
+    : startValue(startValue), offsetOnReverse(offsetOnReverse),
+      accInitLong(accInitLong), accLong(accLong), accMaxLong(accMaxLong),
+      accInitShort(accInitShort), accShort(accShort), accMaxShort(accMaxShort) {}
+
+void SAREXT::calculate(const float* high, const float* low,
+                       float* output, int size) noexcept(false) {
+    if (size <= 0) {
+        throw std::invalid_argument("SAREXT: invalid size");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    sarextKernel<<<1,1>>>(high, low, output, startValue, offsetOnReverse,
+                          accInitLong, accLong, accMaxLong,
+                          accInitShort, accShort, accMaxShort, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void SAREXT::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* high = input;
+    const float* low = input + size;
+    calculate(high, low, output, size);
+}

--- a/src/indicators/StdDev.cu
+++ b/src/indicators/StdDev.cu
@@ -1,0 +1,35 @@
+#include <indicators/StdDev.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+#include <math.h>
+
+__global__ void stddevKernel(const float* __restrict__ input, float* __restrict__ output,
+                             int period, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= period - 1 && idx < size) {
+        float mean = 0.0f;
+        for (int j = 0; j < period; ++j)
+            mean += input[idx - j];
+        mean /= period;
+        float sumsq = 0.0f;
+        for (int j = 0; j < period; ++j) {
+            float diff = input[idx - j] - mean;
+            sumsq += diff * diff;
+        }
+        output[idx] = sqrtf(sumsq / period);
+    }
+}
+
+StdDev::StdDev(int period) : period(period) {}
+
+void StdDev::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (period <= 0 || period > size) {
+        throw std::invalid_argument("StdDev: invalid period");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    stddevKernel<<<grid, block>>>(input, output, period, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/src/indicators/StochasticFast.cu
+++ b/src/indicators/StochasticFast.cu
@@ -1,0 +1,61 @@
+#include <indicators/StochasticFast.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+#include <math.h>
+
+__global__ void stochfKernel(const float* __restrict__ high,
+                             const float* __restrict__ low,
+                             const float* __restrict__ close,
+                             float* __restrict__ kOut,
+                             float* __restrict__ dOut,
+                             int kPeriod, int dPeriod, int size) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        float nan = nanf("");
+        for (int i = 0; i < size; ++i) {
+            kOut[i] = nan;
+            dOut[i] = nan;
+        }
+        for (int i = kPeriod - 1; i < size; ++i) {
+            float highest = high[i];
+            float lowest = low[i];
+            for (int j = 1; j < kPeriod; ++j) {
+                float h = high[i - j];
+                float l = low[i - j];
+                if (h > highest) highest = h;
+                if (l < lowest)  lowest = l;
+            }
+            float denom = highest - lowest;
+            kOut[i] = denom == 0.0f ? 0.0f : (close[i] - lowest) / denom * 100.0f;
+        }
+        int start = kPeriod + dPeriod - 2;
+        for (int i = start; i < size; ++i) {
+            float sum = 0.0f;
+            for (int j = 0; j < dPeriod; ++j) {
+                sum += kOut[i - j];
+            }
+            dOut[i] = sum / dPeriod;
+        }
+    }
+}
+
+StochasticFast::StochasticFast(int kPeriod, int dPeriod) : kPeriod(kPeriod), dPeriod(dPeriod) {}
+
+void StochasticFast::calculate(const float* high, const float* low, const float* close,
+                               float* output, int size) noexcept(false) {
+    if (kPeriod <= 0 || dPeriod <= 0 || kPeriod > size) {
+        throw std::invalid_argument("StochasticFast: invalid periods");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, 2 * size * sizeof(float)));
+    float* kOut = output;
+    float* dOut = output + size;
+    stochfKernel<<<1,1>>>(high, low, close, kOut, dOut, kPeriod, dPeriod, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void StochasticFast::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* high = input;
+    const float* low = input + size;
+    const float* close = input + 2 * size;
+    calculate(high, low, close, output, size);
+}

--- a/tests/cpp/test_change.cpp
+++ b/tests/cpp/test_change.cpp
@@ -1,0 +1,20 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, Change) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+
+  std::vector<float> out(N, 0.0f), ref(N, std::numeric_limits<float>::quiet_NaN());
+
+  int p = 5;
+  ctStatus_t rc = ct_change(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_change failed";
+  for (int i = p; i < N; ++i)
+    ref[i] = x[i] - x[i - p];
+  expect_approx_equal(out, ref);
+  for (int i = 0; i < p; ++i)
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
+}

--- a/tests/cpp/test_sarext.cpp
+++ b/tests/cpp/test_sarext.cpp
@@ -1,0 +1,74 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+static std::vector<float> sarext_ref(const std::vector<float>& high,
+                                     const std::vector<float>& low,
+                                     float startValue, float offset,
+                                     float accInitLong, float accLong, float accMaxLong,
+                                     float accInitShort, float accShort, float accMaxShort) {
+  size_t n = high.size();
+  std::vector<float> out(n);
+  float sar = (startValue != 0.0f) ? startValue : low[0];
+  bool longPos = true;
+  float af = accInitLong;
+  float ep = high[0];
+  out[0] = sar;
+  for (size_t i = 1; i < n; ++i) {
+    sar = sar + af * (ep - sar);
+    if (longPos) {
+      sar = std::min(sar, low[i - 1]);
+      if (low[i] < sar) {
+        longPos = false;
+        sar = ep + offset;
+        ep = low[i];
+        af = accInitShort;
+        sar = std::max(sar, high[i - 1]);
+      } else if (high[i] > ep) {
+        ep = high[i];
+        af = std::min(af + accLong, accMaxLong);
+      }
+    } else {
+      sar = std::max(sar, high[i - 1]);
+      if (high[i] > sar) {
+        longPos = true;
+        sar = ep - offset;
+        ep = high[i];
+        af = accInitLong;
+        sar = std::min(sar, low[i - 1]);
+      } else if (low[i] < ep) {
+        ep = low[i];
+        af = std::min(af + accShort, accMaxShort);
+      }
+    }
+    out[i] = sar;
+  }
+  return out;
+}
+
+TEST(Tacuda, SAREXTTrending) {
+  std::vector<float> high = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f};
+  std::vector<float> low = {0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f};
+  const int N = high.size();
+  std::vector<float> out(N, 0.0f);
+  ctStatus_t rc = ct_sarext(high.data(), low.data(), out.data(), N,
+                            0.0f, 0.0f, 0.02f, 0.02f, 0.2f,
+                            0.02f, 0.02f, 0.2f);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_sarext failed";
+  auto ref = sarext_ref(high, low, 0.0f, 0.0f, 0.02f, 0.02f, 0.2f,
+                        0.02f, 0.02f, 0.2f);
+  expect_approx_equal(out, ref);
+}
+
+TEST(Tacuda, SAREXTRanging) {
+  std::vector<float> high = {5.f, 6.f, 5.5f, 6.2f, 5.8f, 6.4f, 5.9f, 6.5f};
+  std::vector<float> low = {4.f, 5.f, 4.5f, 5.2f, 4.8f, 5.4f, 4.9f, 5.5f};
+  const int N = high.size();
+  std::vector<float> out(N, 0.0f);
+  ctStatus_t rc = ct_sarext(high.data(), low.data(), out.data(), N,
+                            0.0f, 0.0f, 0.02f, 0.02f, 0.2f,
+                            0.02f, 0.02f, 0.2f);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_sarext failed";
+  auto ref = sarext_ref(high, low, 0.0f, 0.0f, 0.02f, 0.02f, 0.2f,
+                        0.02f, 0.02f, 0.2f);
+  expect_approx_equal(out, ref);
+}

--- a/tests/cpp/test_stddev.cpp
+++ b/tests/cpp/test_stddev.cpp
@@ -1,0 +1,30 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, StdDev) {
+  const int N = 100;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::cos(0.1f * i);
+
+  std::vector<float> out(N, 0.0f), ref(N, std::numeric_limits<float>::quiet_NaN());
+
+  int p = 5;
+  ctStatus_t rc = ct_stddev(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_stddev failed";
+  for (int i = p - 1; i < N; ++i) {
+    float mean = 0.0f;
+    for (int j = 0; j < p; ++j)
+      mean += x[i - j];
+    mean /= p;
+    float sumsq = 0.0f;
+    for (int j = 0; j < p; ++j) {
+      float d = x[i - j] - mean;
+      sumsq += d * d;
+    }
+    ref[i] = std::sqrt(sumsq / p);
+  }
+  expect_approx_equal(out, ref);
+  for (int i = 0; i < p - 1; ++i)
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
+}

--- a/tests/cpp/test_stochf.cpp
+++ b/tests/cpp/test_stochf.cpp
@@ -1,0 +1,49 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, StochF) {
+  std::vector<float> high = {48.70f, 48.72f, 48.90f, 48.87f, 48.82f,
+                             49.05f, 49.20f, 49.35f, 49.92f, 50.19f,
+                             50.12f, 49.66f, 49.88f, 50.19f, 50.36f};
+  std::vector<float> low = {47.79f, 48.14f, 48.39f, 48.37f, 48.24f,
+                            48.64f, 48.94f, 48.86f, 49.50f, 49.87f,
+                            49.20f, 48.90f, 49.43f, 49.73f, 49.26f};
+  std::vector<float> close = {48.16f, 48.61f, 48.75f, 48.63f, 48.74f,
+                              49.03f, 49.07f, 49.32f, 49.91f, 49.91f,
+                              49.40f, 49.50f, 49.75f, 49.87f, 50.13f};
+  const int N = high.size();
+  std::vector<float> k(N, 0.0f), d(N, 0.0f),
+      refK(N, std::numeric_limits<float>::quiet_NaN()),
+      refD(N, std::numeric_limits<float>::quiet_NaN());
+
+  int kP = 5, dP = 3;
+  ctStatus_t rc = ct_stochf(high.data(), low.data(), close.data(), k.data(), d.data(), N, kP, dP);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_stochf failed";
+
+  for (int i = kP - 1; i < N; ++i) {
+    float highest = high[i];
+    float lowest = low[i];
+    for (int j = 1; j < kP; ++j) {
+      float h = high[i - j];
+      float l = low[i - j];
+      if (h > highest) highest = h;
+      if (l < lowest)  lowest = l;
+    }
+    float denom = highest - lowest;
+    refK[i] = denom == 0.0f ? 0.0f : (close[i] - lowest) / denom * 100.0f;
+  }
+  int start = kP + dP - 2;
+  for (int i = start; i < N; ++i) {
+    float sum = 0.0f;
+    for (int j = 0; j < dP; ++j)
+      sum += refK[i - j];
+    refD[i] = sum / dP;
+  }
+
+  expect_approx_equal(k, refK);
+  expect_approx_equal(d, refD);
+  for (int i = 0; i < kP - 1; ++i)
+    EXPECT_TRUE(std::isnan(k[i])) << "expected NaN at head " << i;
+  for (int i = 0; i < start; ++i)
+    EXPECT_TRUE(std::isnan(d[i])) << "expected NaN at head " << i;
+}


### PR DESCRIPTION
## Summary
- add Change indicator for price differences
- add standard deviation computation
- implement extended SAR with separate acceleration parameters
- introduce fast stochastic oscillator
- expose new indicators through the C API and add tests

## Testing
- `CXX=g++-12 CC=gcc-12 cmake -S . -B build`
- `cmake --build build --target tacuda`
- `cmake --build build -j 4` *(fails: default argument & nested defs in tests/cpp/test_utils.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c8acd168832984e6cf8828dfc080