### PR TITLE
Add stochastic RSI, summation, T3, true range, and triangular MA indicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,11 @@ set(INDICATOR_SOURCES
     src/indicators/NATR.cu
     src/indicators/PPO.cu
     src/indicators/PVO.cu
+    src/indicators/SUM.cu
+    src/indicators/TRANGE.cu
+    src/indicators/TRIMA.cu
+    src/indicators/T3.cu
+    src/indicators/StochRSI.cu
 )
 
 add_library(tacuda SHARED

--- a/bindings/csharp/CudaTaLib.cs
+++ b/bindings/csharp/CudaTaLib.cs
@@ -1,82 +1,107 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace CudaTaLib
-{
-    public static class Native
-    {
-        #if WINDOWS
-            const string LIB = "tacuda.dll";
-        #elif OSX
-            const string LIB = "libtacuda.dylib";
-        #else
-            const string LIB = "libtacuda.so";
-        #endif
+namespace CudaTaLib {
+public static class Native {
+#if WINDOWS
+  const string LIB = "tacuda.dll";
+#elif OSX
+  const string LIB = "libtacuda.dylib";
+#else
+  const string LIB = "libtacuda.so";
+#endif
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_sma(float[] input, float[] output, int size, int period);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_sma(float[] input, float[] output, int size,
+                                  int period);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_wma(float[] input, float[] output, int size, int period);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_wma(float[] input, float[] output, int size,
+                                  int period);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_momentum(float[] input, float[] output, int size, int period);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_momentum(float[] input, float[] output, int size,
+                                       int period);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_macd_line(float[] input, float[] output, int size, int fast, int slow);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_macd_line(float[] input, float[] output, int size,
+                                        int fast, int slow);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_rsi(float[] input, float[] output, int size, int period);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_rsi(float[] input, float[] output, int size,
+                                  int period);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_atr(float[] high, float[] low, float[] close,
-                                        float[] output, int size, int period, float initial);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_atr(float[] high, float[] low, float[] close,
+                                  float[] output, int size, int period,
+                                  float initial);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_stochastic(float[] high, float[] low, float[] close,
-                                               float[] kOut, float[] dOut,
-                                               int size, int kPeriod, int dPeriod);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_stochastic(float[] high, float[] low,
+                                         float[] close, float[] kOut,
+                                         float[] dOut, int size, int kPeriod,
+                                         int dPeriod);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_cci(float[] high, float[] low, float[] close,
-                                        float[] output, int size, int period);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_cci(float[] high, float[] low, float[] close,
+                                  float[] output, int size, int period);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_adx(float[] high, float[] low, float[] close,
-                                        float[] output, int size, int period);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_adx(float[] high, float[] low, float[] close,
+                                  float[] output, int size, int period);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_ultosc(float[] high, float[] low, float[] close,
-                                           float[] output, int size,
-                                           int shortPeriod, int mediumPeriod, int longPeriod);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_ultosc(float[] high, float[] low, float[] close,
+                                     float[] output, int size, int shortPeriod,
+                                     int mediumPeriod, int longPeriod);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_sar(float[] high, float[] low,
-                                        float[] output, int size,
-                                        float step, float maxAcceleration);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_sar(float[] high, float[] low, float[] output,
+                                  int size, float step, float maxAcceleration);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_obv(float[] price, float[] volume,
-                                        float[] output, int size);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_obv(float[] price, float[] volume, float[] output,
+                                  int size);
 
-        [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ct_aroon(float[] high, float[] low,
-                                          float[] up, float[] down, float[] osc,
-                                          int size, int upPeriod, int downPeriod);
-    }
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_aroon(float[] high, float[] low, float[] up,
+                                    float[] down, float[] osc, int size,
+                                    int upPeriod, int downPeriod);
 
-    public class Example
-    {
-        public static void Main(string[] args)
-        {
-            int N = 1024;
-            var x = new float[N];
-            for (int i = 0; i < N; ++i) x[i] = (float)Math.Sin(0.01 * i);
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_trange(float[] high, float[] low, float[] close,
+                                     float[] output, int size);
 
-            var outArr = new float[N];
-            int rc = Native.ct_sma(x, outArr, N, 14);
-            if (rc != 0) throw new Exception("ct_sma failed");
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_sum(float[] input, float[] output, int size,
+                                  int period);
+
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_t3(float[] input, float[] output, int size,
+                                 int period, float vFactor);
+
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_trima(float[] input, float[] output, int size,
+                                    int period);
+
+  [DllImport(LIB, CallingConvention = CallingConvention.Cdecl)]
+  public static extern int ct_stochrsi(float[] input, float[] kOut,
+                                       float[] dOut, int size, int rsiPeriod,
+                                       int kPeriod, int dPeriod);
+}
+
+public class Example {
+  public static void Main(string[] args) {
+    int N = 1024;
+    var x = new float[N];
+    for (int i = 0; i < N; ++i)
+      x[i] = (float)Math.Sin(0.01 * i);
+
+    var outArr = new float[N];
+    int rc = Native.ct_sma(x, outArr, N, 14);
+    if (rc != 0)
+      throw new Exception("ct_sma failed");
             Console.WriteLine("SMA[0..4]: " + string.Join(\", \", outArr[0], outArr[1], outArr[2], outArr[3], outArr[4]));
-        }
-    }
+  }
+}
 }

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -109,6 +109,16 @@ _lib.ct_ultosc.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes
                            ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
                            ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
 _lib.ct_ultosc.restype  = ctypes.c_int
+_lib.ct_trange.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_trange.restype  = ctypes.c_int
+_lib.ct_sum.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.c_int, ctypes.c_int]
+_lib.ct_sum.restype  = ctypes.c_int
+_lib.ct_t3.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.c_int, ctypes.c_int, ctypes.c_float]
+_lib.ct_t3.restype  = ctypes.c_int
+_lib.ct_trima.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.c_int, ctypes.c_int]
+_lib.ct_trima.restype  = ctypes.c_int
+_lib.ct_stochrsi.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+_lib.ct_stochrsi.restype  = ctypes.c_int
 
 def _as_float_ptr(arr):
     import numpy as np
@@ -307,3 +317,66 @@ def obv(price, volume):
     if rc != 0:
         raise RuntimeError("ct_obv failed")
     return out
+
+def trange(high, low, close):
+    import numpy as np
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if high.shape != low.shape or high.shape != close.shape:
+        raise ValueError("high, low, close must have same shape")
+    out = np.zeros_like(close)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, po = _as_float_ptr(out)
+    rc = _lib.ct_trange(ph, pl, pc, po, close.size)
+    if rc != 0:
+        raise RuntimeError("ct_trange failed")
+    return out
+
+def summation(x, period):
+    import numpy as np
+    x = np.asarray(x, dtype=np.float32)
+    out = np.zeros_like(x)
+    _, px = _as_float_ptr(x)
+    _, po = _as_float_ptr(out)
+    rc = _lib.ct_sum(px, po, x.size, int(period))
+    if rc != 0:
+        raise RuntimeError("ct_sum failed")
+    return out
+
+def t3(x, period, v_factor):
+    import numpy as np
+    x = np.asarray(x, dtype=np.float32)
+    out = np.zeros_like(x)
+    _, px = _as_float_ptr(x)
+    _, po = _as_float_ptr(out)
+    rc = _lib.ct_t3(px, po, x.size, int(period), float(v_factor))
+    if rc != 0:
+        raise RuntimeError("ct_t3 failed")
+    return out
+
+def trima(x, period):
+    import numpy as np
+    x = np.asarray(x, dtype=np.float32)
+    out = np.zeros_like(x)
+    _, px = _as_float_ptr(x)
+    _, po = _as_float_ptr(out)
+    rc = _lib.ct_trima(px, po, x.size, int(period))
+    if rc != 0:
+        raise RuntimeError("ct_trima failed")
+    return out
+
+def stochrsi(x, rsi_period, k_period, d_period):
+    import numpy as np
+    x = np.asarray(x, dtype=np.float32)
+    k = np.zeros_like(x)
+    d = np.zeros_like(x)
+    _, px = _as_float_ptr(x)
+    _, pk = _as_float_ptr(k)
+    _, pd = _as_float_ptr(d)
+    rc = _lib.ct_stochrsi(px, pk, pd, x.size, int(rsi_period), int(k_period), int(d_period))
+    if rc != 0:
+        raise RuntimeError("ct_stochrsi failed")
+    return k, d

--- a/include/indicators/SUM.h
+++ b/include/indicators/SUM.h
@@ -1,0 +1,16 @@
+#ifndef SUM_H
+#define SUM_H
+
+#include "Indicator.h"
+
+class SUM : public Indicator {
+public:
+  explicit SUM(int period);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+
+private:
+  int period;
+};
+
+#endif

--- a/include/indicators/StochRSI.h
+++ b/include/indicators/StochRSI.h
@@ -1,0 +1,18 @@
+#ifndef STOCHRSI_H
+#define STOCHRSI_H
+
+#include "Indicator.h"
+
+class StochRSI : public Indicator {
+public:
+  StochRSI(int rsiPeriod, int kPeriod, int dPeriod);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+
+private:
+  int rsiPeriod;
+  int kPeriod;
+  int dPeriod;
+};
+
+#endif

--- a/include/indicators/T3.h
+++ b/include/indicators/T3.h
@@ -1,0 +1,17 @@
+#ifndef T3_H
+#define T3_H
+
+#include "Indicator.h"
+
+class T3 : public Indicator {
+public:
+  T3(int period, float vFactor);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+
+private:
+  int period;
+  float vFactor;
+};
+
+#endif

--- a/include/indicators/TRANGE.h
+++ b/include/indicators/TRANGE.h
@@ -1,0 +1,15 @@
+#ifndef TRANGE_H
+#define TRANGE_H
+
+#include "Indicator.h"
+
+class TRANGE : public Indicator {
+public:
+  TRANGE() = default;
+  void calculate(const float *high, const float *low, const float *close,
+                 float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/TRIMA.h
+++ b/include/indicators/TRIMA.h
@@ -1,0 +1,16 @@
+#ifndef TRIMA_H
+#define TRIMA_H
+
+#include "Indicator.h"
+
+class TRIMA : public Indicator {
+public:
+  explicit TRIMA(int period);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+
+private:
+  int period;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -45,6 +45,10 @@ CTAPI_EXPORT ctStatus_t ct_dema(const float *host_input, float *host_output,
                                 int size, int period);
 CTAPI_EXPORT ctStatus_t ct_tema(const float *host_input, float *host_output,
                                 int size, int period);
+CTAPI_EXPORT ctStatus_t ct_t3(const float *host_input, float *host_output,
+                              int size, int period, float vFactor);
+CTAPI_EXPORT ctStatus_t ct_trima(const float *host_input, float *host_output,
+                                 int size, int period);
 CTAPI_EXPORT ctStatus_t ct_trix(const float *host_input, float *host_output,
                                 int size, int period);
 CTAPI_EXPORT ctStatus_t ct_max(const float *host_input, float *host_output,
@@ -53,6 +57,8 @@ CTAPI_EXPORT ctStatus_t ct_min(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_stddev(const float *host_input, float *host_output,
                                   int size, int period);
+CTAPI_EXPORT ctStatus_t ct_sum(const float *host_input, float *host_output,
+                               int size, int period);
 CTAPI_EXPORT ctStatus_t ct_rsi(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_kama(const float *host_input, float *host_output,
@@ -85,16 +91,21 @@ CTAPI_EXPORT ctStatus_t ct_atr(const float *host_high, const float *host_low,
 CTAPI_EXPORT ctStatus_t ct_natr(const float *host_high, const float *host_low,
                                 const float *host_close, float *host_output,
                                 int size, int period);
+CTAPI_EXPORT ctStatus_t ct_trange(const float *host_high, const float *host_low,
+                                  const float *host_close, float *host_output,
+                                  int size);
 CTAPI_EXPORT ctStatus_t ct_stochastic(const float *host_high,
                                       const float *host_low,
                                       const float *host_close, float *host_k,
                                       float *host_d, int size, int kPeriod,
                                       int dPeriod);
-CTAPI_EXPORT ctStatus_t ct_stochf(const float *host_high,
-                                  const float *host_low,
+CTAPI_EXPORT ctStatus_t ct_stochf(const float *host_high, const float *host_low,
                                   const float *host_close, float *host_k,
                                   float *host_d, int size, int kPeriod,
                                   int dPeriod);
+CTAPI_EXPORT ctStatus_t ct_stochrsi(const float *host_input, float *host_k,
+                                    float *host_d, int size, int rsiPeriod,
+                                    int kPeriod, int dPeriod);
 CTAPI_EXPORT ctStatus_t ct_cci(const float *host_high, const float *host_low,
                                const float *host_close, float *host_output,
                                int size, int period);
@@ -129,11 +140,11 @@ CTAPI_EXPORT ctStatus_t ct_sar(const float *host_high, const float *host_low,
                                float *host_output, int size, float step,
                                float maxAcceleration);
 CTAPI_EXPORT ctStatus_t ct_sarext(const float *host_high, const float *host_low,
-                                  float *host_output, int size, float startValue,
-                                  float offsetOnReverse, float accInitLong,
-                                  float accLong, float accMaxLong,
-                                  float accInitShort, float accShort,
-                                  float accMaxShort);
+                                  float *host_output, int size,
+                                  float startValue, float offsetOnReverse,
+                                  float accInitLong, float accLong,
+                                  float accMaxLong, float accInitShort,
+                                  float accShort, float accMaxShort);
 CTAPI_EXPORT ctStatus_t ct_aroon(const float *host_high, const float *host_low,
                                  float *host_up, float *host_down,
                                  float *host_osc, int size, int upPeriod,

--- a/src/indicators/SUM.cu
+++ b/src/indicators/SUM.cu
@@ -1,0 +1,39 @@
+#include <indicators/SUM.h>
+#include <stdexcept>
+#include <thrust/device_ptr.h>
+#include <thrust/scan.h>
+#include <utils/CudaUtils.h>
+
+__global__ void sumKernelPrefix(const float *__restrict__ prefix,
+                                float *__restrict__ output, int period,
+                                int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx <= size - period) {
+    float prev = (idx == 0) ? 0.0f : prefix[idx - 1];
+    output[idx] = prefix[idx + period - 1] - prev;
+  }
+}
+
+SUM::SUM(int period) : period(period) {}
+
+void SUM::calculate(const float *input, float *output,
+                    int size) noexcept(false) {
+  if (period <= 0 || period > size) {
+    throw std::invalid_argument("SUM: invalid period");
+  }
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+
+  float *prefix = nullptr;
+  CUDA_CHECK(cudaMalloc(&prefix, size * sizeof(float)));
+  thrust::device_ptr<const float> inPtr(input);
+  thrust::device_ptr<float> prePtr(prefix);
+  thrust::inclusive_scan(inPtr, inPtr + size, prePtr);
+
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  sumKernelPrefix<<<grid, block>>>(prefix, output, period, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  CUDA_CHECK(cudaFree(prefix));
+}

--- a/src/indicators/StochRSI.cu
+++ b/src/indicators/StochRSI.cu
@@ -1,0 +1,80 @@
+#include <indicators/StochRSI.h>
+#include <math.h>
+#include <stdexcept>
+#include <utils/CudaUtils.h>
+
+__global__ void stochRsiKernel(const float *__restrict__ input,
+                               float *__restrict__ rsi,
+                               float *__restrict__ kOut,
+                               float *__restrict__ dOut, int rsiPeriod,
+                               int kPeriod, int dPeriod, int size) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    float nan = nanf("");
+    for (int i = 0; i < size; ++i) {
+      rsi[i] = nan;
+      kOut[i] = nan;
+      dOut[i] = nan;
+    }
+    for (int i = rsiPeriod; i < size; ++i) {
+      float gain = 0.0f, loss = 0.0f;
+      for (int j = 0; j < rsiPeriod; ++j) {
+        float diff = input[i - j] - input[i - j - 1];
+        if (diff > 0.0f)
+          gain += diff;
+        else
+          loss -= diff;
+      }
+      float avgGain = gain / rsiPeriod;
+      float avgLoss = loss / rsiPeriod;
+      float val;
+      if (avgLoss == 0.0f)
+        val = (avgGain == 0.0f) ? 50.0f : 100.0f;
+      else if (avgGain == 0.0f)
+        val = 0.0f;
+      else {
+        float rs = avgGain / avgLoss;
+        val = 100.0f - 100.0f / (1.0f + rs);
+      }
+      rsi[i] = val;
+      if (i >= rsiPeriod + kPeriod - 1) {
+        float highest = rsi[i];
+        float lowest = rsi[i];
+        for (int j = 1; j < kPeriod; ++j) {
+          float v = rsi[i - j];
+          if (v > highest)
+            highest = v;
+          if (v < lowest)
+            lowest = v;
+        }
+        float denom = highest - lowest;
+        kOut[i] = denom == 0.0f ? 0.0f : (rsi[i] - lowest) / denom * 100.0f;
+        if (i >= rsiPeriod + kPeriod + dPeriod - 2) {
+          float sum = 0.0f;
+          for (int j = 0; j < dPeriod; ++j)
+            sum += kOut[i - j];
+          dOut[i] = sum / dPeriod;
+        }
+      }
+    }
+  }
+}
+
+StochRSI::StochRSI(int rsiPeriod, int kPeriod, int dPeriod)
+    : rsiPeriod(rsiPeriod), kPeriod(kPeriod), dPeriod(dPeriod) {}
+
+void StochRSI::calculate(const float *input, float *output,
+                         int size) noexcept(false) {
+  if (rsiPeriod <= 0 || kPeriod <= 0 || dPeriod <= 0 ||
+      size <= rsiPeriod + kPeriod + dPeriod - 2) {
+    throw std::invalid_argument("StochRSI: invalid parameters");
+  }
+  float *rsi = nullptr;
+  CUDA_CHECK(cudaMalloc(&rsi, size * sizeof(float)));
+  float *kOut = output;
+  float *dOut = output + size;
+  stochRsiKernel<<<1, 1>>>(input, rsi, kOut, dOut, rsiPeriod, kPeriod, dPeriod,
+                           size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+  cudaFree(rsi);
+}

--- a/src/indicators/T3.cu
+++ b/src/indicators/T3.cu
@@ -1,0 +1,71 @@
+#include <indicators/EMA.h>
+#include <indicators/T3.h>
+#include <stdexcept>
+#include <utils/CudaUtils.h>
+
+__global__ void t3Kernel(const float *__restrict__ e3,
+                         const float *__restrict__ e4,
+                         const float *__restrict__ e5,
+                         const float *__restrict__ e6,
+                         float *__restrict__ output, float c1, float c2,
+                         float c3, float c4, int period, int valid) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < valid) {
+    int p1 = period - 1;
+    output[idx] = c1 * e6[idx + 3 * p1] + c2 * e5[idx + 2 * p1] +
+                  c3 * e4[idx + p1] + c4 * e3[idx];
+  }
+}
+
+T3::T3(int period, float vFactor) : period(period), vFactor(vFactor) {}
+
+void T3::calculate(const float *input, float *output,
+                   int size) noexcept(false) {
+  if (period <= 0 || size < 3 * period - 2) {
+    throw std::invalid_argument("T3: invalid period");
+  }
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+
+  float *e1 = nullptr, *e2 = nullptr, *e3 = nullptr, *e4 = nullptr,
+        *e5 = nullptr, *e6 = nullptr;
+  CUDA_CHECK(cudaMalloc(&e1, size * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&e2, size * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&e3, size * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&e4, size * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&e5, size * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&e6, size * sizeof(float)));
+
+  EMA ema(period);
+  ema.calculate(input, e1, size);
+  int size2 = size - period + 1;
+  ema.calculate(e1, e2, size2);
+  int size3 = size2 - period + 1;
+  ema.calculate(e2, e3, size3);
+  int size4 = size3 - period + 1;
+  ema.calculate(e3, e4, size4);
+  int size5 = size4 - period + 1;
+  ema.calculate(e4, e5, size5);
+  int size6 = size5 - period + 1;
+  ema.calculate(e5, e6, size6);
+
+  float b = vFactor;
+  float c1 = -b * b * b;
+  float c2 = 3 * b * b + 3 * b * b * b;
+  float c3 = -3 * b - 6 * b * b - 3 * b * b * b;
+  float c4 = 1 + 3 * b + 3 * b * b + b * b * b;
+
+  int valid = size - 3 * period + 3;
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(valid);
+  t3Kernel<<<grid, block>>>(e3, e4, e5, e6, output, c1, c2, c3, c4, period,
+                            valid);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  cudaFree(e1);
+  cudaFree(e2);
+  cudaFree(e3);
+  cudaFree(e4);
+  cudaFree(e5);
+  cudaFree(e6);
+}

--- a/src/indicators/TRANGE.cu
+++ b/src/indicators/TRANGE.cu
@@ -1,0 +1,42 @@
+#include <indicators/TRANGE.h>
+#include <math.h>
+#include <stdexcept>
+#include <utils/CudaUtils.h>
+
+__global__ void trangeKernel(const float *__restrict__ high,
+                             const float *__restrict__ low,
+                             const float *__restrict__ close,
+                             float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < size) {
+    if (idx == 0) {
+      output[idx] = high[0] - low[0];
+    } else {
+      float tr1 = high[idx] - low[idx];
+      float tr2 = fabsf(high[idx] - close[idx - 1]);
+      float tr3 = fabsf(low[idx] - close[idx - 1]);
+      float m = tr1 > tr2 ? tr1 : tr2;
+      output[idx] = m > tr3 ? m : tr3;
+    }
+  }
+}
+
+void TRANGE::calculate(const float *high, const float *low, const float *close,
+                       float *output, int size) noexcept(false) {
+  if (size <= 0) {
+    throw std::invalid_argument("TRANGE: invalid size");
+  }
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  trangeKernel<<<grid, block>>>(high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void TRANGE::calculate(const float *input, float *output,
+                       int size) noexcept(false) {
+  const float *high = input;
+  const float *low = input + size;
+  const float *close = input + 2 * size;
+  calculate(high, low, close, output, size);
+}

--- a/src/indicators/TRIMA.cu
+++ b/src/indicators/TRIMA.cu
@@ -1,0 +1,27 @@
+#include <indicators/SMA.h>
+#include <indicators/TRIMA.h>
+#include <stdexcept>
+#include <utils/CudaUtils.h>
+
+TRIMA::TRIMA(int period) : period(period) {}
+
+void TRIMA::calculate(const float *input, float *output,
+                      int size) noexcept(false) {
+  if (period <= 0 || size < period) {
+    throw std::invalid_argument("TRIMA: invalid period");
+  }
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  int p1 = (period + 1) / 2;
+  int p2 = (period % 2 == 0) ? (p1 + 1) : p1;
+
+  float *tmp = nullptr;
+  CUDA_CHECK(cudaMalloc(&tmp, size * sizeof(float)));
+
+  SMA sma1(p1);
+  sma1.calculate(input, tmp, size);
+  int size2 = size - p1 + 1;
+  SMA sma2(p2);
+  sma2.calculate(tmp, output, size2);
+
+  CUDA_CHECK(cudaFree(tmp));
+}

--- a/tests/cpp/test_stochrsi.cpp
+++ b/tests/cpp/test_stochrsi.cpp
@@ -1,0 +1,66 @@
+#include "test_utils.hpp"
+#include <tacuda.h>
+
+TEST(Tacuda, StochRSI) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+
+  std::vector<float> k(N, 0.0f), d(N, 0.0f);
+  std::vector<float> refK(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> refD(N, std::numeric_limits<float>::quiet_NaN());
+
+  int rsiP = 14, kP = 5, dP = 3;
+  ctStatus_t rc = ct_stochrsi(x.data(), k.data(), d.data(), N, rsiP, kP, dP);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_stochrsi failed";
+
+  std::vector<float> rsi(N, std::numeric_limits<float>::quiet_NaN());
+  for (int i = rsiP; i < N; ++i) {
+    float gain = 0.0f, loss = 0.0f;
+    for (int j = 0; j < rsiP; ++j) {
+      float diff = x[i - j] - x[i - j - 1];
+      if (diff > 0.0f)
+        gain += diff;
+      else
+        loss -= diff;
+    }
+    float avgGain = gain / rsiP;
+    float avgLoss = loss / rsiP;
+    float val;
+    if (avgLoss == 0.0f)
+      val = (avgGain == 0.0f) ? 50.0f : 100.0f;
+    else if (avgGain == 0.0f)
+      val = 0.0f;
+    else {
+      float rs = avgGain / avgLoss;
+      val = 100.0f - 100.0f / (1.0f + rs);
+    }
+    rsi[i] = val;
+    if (i >= rsiP + kP - 1) {
+      float highest = rsi[i];
+      float lowest = rsi[i];
+      for (int j = 1; j < kP; ++j) {
+        float v = rsi[i - j];
+        if (v > highest)
+          highest = v;
+        if (v < lowest)
+          lowest = v;
+      }
+      float denom = highest - lowest;
+      refK[i] = denom == 0.0f ? 0.0f : (rsi[i] - lowest) / denom * 100.0f;
+      if (i >= rsiP + kP + dP - 2) {
+        float sum = 0.0f;
+        for (int j = 0; j < dP; ++j)
+          sum += refK[i - j];
+        refD[i] = sum / dP;
+      }
+    }
+  }
+  expect_approx_equal(k, refK);
+  expect_approx_equal(d, refD);
+  for (int i = 0; i < rsiP + kP + dP - 2; ++i) {
+    EXPECT_TRUE(std::isnan(k[i])) << "expected NaN at head " << i;
+    EXPECT_TRUE(std::isnan(d[i])) << "expected NaN at head " << i;
+  }
+}

--- a/tests/cpp/test_sum.cpp
+++ b/tests/cpp/test_sum.cpp
@@ -1,0 +1,25 @@
+#include "test_utils.hpp"
+#include <tacuda.h>
+
+TEST(Tacuda, SUM) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+
+  std::vector<float> out(N, 0.0f), ref(N, 0.0f);
+
+  int p = 5;
+  ctStatus_t rc = ct_sum(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_sum failed";
+  for (int i = 0; i <= N - p; ++i) {
+    float s = 0.0f;
+    for (int k = 0; k < p; ++k)
+      s += x[i + k];
+    ref[i] = s;
+  }
+  expect_approx_equal(out, ref);
+  for (int i = N - p + 1; i < N; ++i) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at tail " << i;
+  }
+}

--- a/tests/cpp/test_t3.cpp
+++ b/tests/cpp/test_t3.cpp
@@ -1,0 +1,68 @@
+#include "test_utils.hpp"
+#include <tacuda.h>
+
+static void ema_ref(const std::vector<float> &in, std::vector<float> &out,
+                    int size, int period) {
+  const float k = 2.0f / (period + 1.0f);
+  for (int idx = 0; idx <= size - period; ++idx) {
+    float weight = 1.0f;
+    float weightedSum = in[idx + period - 1];
+    float weightSum = 1.0f;
+    for (int i = 1; i < period; ++i) {
+      weight *= (1.0f - k);
+      weightedSum += in[idx + period - 1 - i] * weight;
+      weightSum += weight;
+    }
+    out[idx] = weightedSum / weightSum;
+  }
+}
+
+TEST(Tacuda, T3) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+  std::vector<float> out(N, 0.0f),
+      ref(N, std::numeric_limits<float>::quiet_NaN());
+
+  int p = 5;
+  float v = 0.7f;
+  ctStatus_t rc = ct_t3(x.data(), out.data(), N, p, v);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_t3 failed";
+
+  std::vector<float> e1(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> e2(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> e3(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> e4(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> e5(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> e6(N, std::numeric_limits<float>::quiet_NaN());
+
+  ema_ref(x, e1, N, p);
+  int size2 = N - p + 1;
+  ema_ref(e1, e2, size2, p);
+  int size3 = size2 - p + 1;
+  ema_ref(e2, e3, size3, p);
+  int size4 = size3 - p + 1;
+  ema_ref(e3, e4, size4, p);
+  int size5 = size4 - p + 1;
+  ema_ref(e4, e5, size5, p);
+  int size6 = size5 - p + 1;
+  ema_ref(e5, e6, size6, p);
+
+  float b = v;
+  float c1 = -b * b * b;
+  float c2 = 3 * b * b + 3 * b * b * b;
+  float c3 = -3 * b - 6 * b * b - 3 * b * b * b;
+  float c4 = 1 + 3 * b + 3 * b * b + b * b * b;
+
+  int valid = N - 3 * p + 3;
+  for (int i = 0; i < valid; ++i) {
+    int p1 = p - 1;
+    ref[i] = c1 * e6[i + 3 * p1] + c2 * e5[i + 2 * p1] + c3 * e4[i + p1] +
+             c4 * e3[i];
+  }
+  expect_approx_equal(out, ref);
+  for (int i = valid; i < N; ++i) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at tail " << i;
+  }
+}

--- a/tests/cpp/test_trange.cpp
+++ b/tests/cpp/test_trange.cpp
@@ -1,0 +1,28 @@
+#include "test_utils.hpp"
+#include <tacuda.h>
+
+TEST(Tacuda, TRANGE) {
+  std::vector<float> high = {48.70f, 48.72f, 48.90f, 48.87f, 48.82f,
+                             49.05f, 49.20f, 49.35f, 49.92f, 50.19f};
+  std::vector<float> low = {47.79f, 48.14f, 48.39f, 48.37f, 48.24f,
+                            48.64f, 48.94f, 48.86f, 49.50f, 49.87f};
+  std::vector<float> close = {48.16f, 48.61f, 48.75f, 48.63f, 48.74f,
+                              49.03f, 49.07f, 49.32f, 49.91f, 49.91f};
+  const int N = high.size();
+  std::vector<float> out(N, 0.0f), ref(N, 0.0f);
+
+  ctStatus_t rc =
+      ct_trange(high.data(), low.data(), close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_trange failed";
+  for (int i = 0; i < N; ++i) {
+    if (i == 0) {
+      ref[i] = high[i] - low[i];
+    } else {
+      float tr1 = high[i] - low[i];
+      float tr2 = std::fabs(high[i] - close[i - 1]);
+      float tr3 = std::fabs(low[i] - close[i - 1]);
+      ref[i] = std::max(tr1, std::max(tr2, tr3));
+    }
+  }
+  expect_approx_equal(out, ref);
+}

--- a/tests/cpp/test_trima.cpp
+++ b/tests/cpp/test_trima.cpp
@@ -1,0 +1,34 @@
+#include "test_utils.hpp"
+#include <tacuda.h>
+
+TEST(Tacuda, TRIMA) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.05f * i);
+
+  std::vector<float> out(N, 0.0f), ref(N, 0.0f),
+      tmp(N, std::numeric_limits<float>::quiet_NaN());
+
+  int p = 5;
+  ctStatus_t rc = ct_trima(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_trima failed";
+  int p1 = (p + 1) / 2;
+  int p2 = (p % 2 == 0) ? (p1 + 1) : p1;
+  for (int i = 0; i <= N - p1; ++i) {
+    float s = 0.0f;
+    for (int j = 0; j < p1; ++j)
+      s += x[i + j];
+    tmp[i] = s / p1;
+  }
+  for (int i = 0; i <= N - p; ++i) {
+    float s = 0.0f;
+    for (int j = 0; j < p2; ++j)
+      s += tmp[i + j];
+    ref[i] = s / p2;
+  }
+  expect_approx_equal(out, ref);
+  for (int i = N - p + 1; i < N; ++i) {
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at tail " << i;
+  }
+}


### PR DESCRIPTION
## Summary
- implement SUM, TRANGE, TRIMA, T3, and StochRSI indicators with CUDA kernels
- expose new indicators through the C API and C#/Python bindings
- add comprehensive unit tests for each new indicator

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce91c514832982e044149eebf3f0