### PR TITLE
Add forecast, typical price, and variance indicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,9 @@ set(INDICATOR_SOURCES
     src/indicators/TRIMA.cu
     src/indicators/T3.cu
     src/indicators/StochRSI.cu
+    src/indicators/TSF.cu
+    src/indicators/TypPrice.cu
+    src/indicators/VAR.cu
 )
 
 add_library(tacuda SHARED

--- a/include/indicators/TSF.h
+++ b/include/indicators/TSF.h
@@ -1,0 +1,14 @@
+#ifndef TSF_H
+#define TSF_H
+
+#include "Indicator.h"
+
+class TSF : public Indicator {
+public:
+    explicit TSF(int period);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int period;
+};
+
+#endif

--- a/include/indicators/TypPrice.h
+++ b/include/indicators/TypPrice.h
@@ -1,0 +1,14 @@
+#ifndef TYPPRICE_H
+#define TYPPRICE_H
+
+#include "Indicator.h"
+
+class TypPrice : public Indicator {
+public:
+    TypPrice() = default;
+    void calculate(const float* high, const float* low, const float* close,
+                   float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/VAR.h
+++ b/include/indicators/VAR.h
@@ -1,0 +1,14 @@
+#ifndef VAR_H
+#define VAR_H
+
+#include "Indicator.h"
+
+class VAR : public Indicator {
+public:
+    explicit VAR(int period);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    int period;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -57,6 +57,8 @@ CTAPI_EXPORT ctStatus_t ct_min(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_stddev(const float *host_input, float *host_output,
                                   int size, int period);
+CTAPI_EXPORT ctStatus_t ct_var(const float *host_input, float *host_output,
+                               int size, int period);
 CTAPI_EXPORT ctStatus_t ct_sum(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_rsi(const float *host_input, float *host_output,
@@ -171,6 +173,10 @@ CTAPI_EXPORT ctStatus_t ct_avgprice(const float *host_open,
 CTAPI_EXPORT ctStatus_t ct_medprice(const float *host_high,
                                     const float *host_low, float *host_output,
                                     int size);
+CTAPI_EXPORT ctStatus_t ct_typprice(const float *host_high,
+                                    const float *host_low,
+                                    const float *host_close, float *host_output,
+                                    int size);
 CTAPI_EXPORT ctStatus_t ct_beta(const float *host_x, const float *host_y,
                                 float *host_output, int size, int period);
 CTAPI_EXPORT ctStatus_t ct_bop(const float *host_open, const float *host_high,
@@ -194,6 +200,8 @@ CTAPI_EXPORT ctStatus_t ct_linearreg_intercept(const float *host_input,
 CTAPI_EXPORT ctStatus_t ct_linearreg_angle(const float *host_input,
                                            float *host_output, int size,
                                            int period);
+CTAPI_EXPORT ctStatus_t ct_tsf(const float *host_input,
+                               float *host_output, int size, int period);
 CTAPI_EXPORT ctStatus_t ct_ht_dcperiod(const float *host_input,
                                        float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_ht_dcphase(const float *host_input,

--- a/src/indicators/TSF.cu
+++ b/src/indicators/TSF.cu
@@ -1,0 +1,38 @@
+#include <indicators/TSF.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+#include <math.h>
+
+__global__ void tsfKernel(const float* __restrict__ in,
+                          float* __restrict__ out,
+                          int period, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx <= size - period) {
+        float sumY = 0.0f, sumXY = 0.0f;
+        for (int i = 0; i < period; ++i) {
+            float y = in[idx + i];
+            sumY += y;
+            sumXY += i * y;
+        }
+        float sumX = 0.5f * period * (period - 1);
+        float sumX2 = (period - 1) * period * (2 * period - 1) / 6.0f;
+        float denom = period * sumX2 - sumX * sumX;
+        float slope = (period * sumXY - sumX * sumY) / denom;
+        float intercept = (sumY - slope * sumX) / period;
+        out[idx] = intercept + slope * period;
+    }
+}
+
+TSF::TSF(int period) : period(period) {}
+
+void TSF::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (period <= 0 || period > size) {
+        throw std::invalid_argument("TSF: invalid period");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    tsfKernel<<<grid, block>>>(input, output, period, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/src/indicators/TypPrice.cu
+++ b/src/indicators/TypPrice.cu
@@ -1,0 +1,33 @@
+#include <indicators/TypPrice.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+
+__global__ void typPriceKernel(const float* __restrict__ high,
+                               const float* __restrict__ low,
+                               const float* __restrict__ close,
+                               float* __restrict__ output,
+                               int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        output[idx] = (high[idx] + low[idx] + close[idx]) / 3.0f;
+    }
+}
+
+void TypPrice::calculate(const float* high, const float* low, const float* close,
+                         float* output, int size) noexcept(false) {
+    if (size <= 0) {
+        throw std::invalid_argument("TypPrice: invalid size");
+    }
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    typPriceKernel<<<grid, block>>>(high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void TypPrice::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* high = input;
+    const float* low = input + size;
+    const float* close = input + 2 * size;
+    calculate(high, low, close, output, size);
+}

--- a/src/indicators/VAR.cu
+++ b/src/indicators/VAR.cu
@@ -1,0 +1,35 @@
+#include <indicators/VAR.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+
+__global__ void varKernel(const float* __restrict__ input,
+                          float* __restrict__ output,
+                          int period, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= period - 1 && idx < size) {
+        float mean = 0.0f;
+        for (int j = 0; j < period; ++j)
+            mean += input[idx - j];
+        mean /= period;
+        float sumsq = 0.0f;
+        for (int j = 0; j < period; ++j) {
+            float diff = input[idx - j] - mean;
+            sumsq += diff * diff;
+        }
+        output[idx] = sumsq / period;
+    }
+}
+
+VAR::VAR(int period) : period(period) {}
+
+void VAR::calculate(const float* input, float* output, int size) noexcept(false) {
+    if (period <= 0 || period > size) {
+        throw std::invalid_argument("VAR: invalid period");
+    }
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    varKernel<<<grid, block>>>(input, output, period, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}

--- a/tests/cpp/test_tsf.cpp
+++ b/tests/cpp/test_tsf.cpp
@@ -1,0 +1,17 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, TSF) {
+  const int N = 128;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::sin(0.03f * i);
+  std::vector<float> out(N, 0.0f);
+  int p = 5;
+  ctStatus_t rc = ct_tsf(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_tsf failed";
+  auto ref = tsf_ref(x, p);
+  expect_approx_equal(out, ref);
+  for (int i = N - p + 1; i < N; ++i)
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at tail " << i;
+}

--- a/tests/cpp/test_typprice.cpp
+++ b/tests/cpp/test_typprice.cpp
@@ -1,0 +1,17 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, TypPrice) {
+  const int N = 100;
+  std::vector<float> high(N), low(N), close(N);
+  for (int i = 0; i < N; ++i) {
+    high[i] = 10.0f + std::sin(0.05f * i);
+    low[i] = high[i] - 1.0f;
+    close[i] = low[i] + 0.5f;
+  }
+  std::vector<float> out(N, 0.0f);
+  ctStatus_t rc = ct_typprice(high.data(), low.data(), close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_typprice failed";
+  auto ref = typprice_ref(high, low, close);
+  expect_approx_equal(out, ref);
+}

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -569,6 +569,16 @@ std::vector<float> sar_ref(const std::vector<float> &high,
           return out;
         }
 
+        std::vector<float> typprice_ref(
+            const std::vector<float> &high, const std::vector<float> &low,
+            const std::vector<float> &close) {
+          int N = high.size();
+          std::vector<float> out(N, 0.0f);
+          for (int i = 0; i < N; ++i)
+            out[i] = (high[i] + low[i] + close[i]) / 3.0f;
+          return out;
+        }
+
         static std::vector<float> run_linearreg_python(
             const std::vector<float> &in, int period, const char *func) {
           std::ostringstream cmd;
@@ -624,6 +634,10 @@ std::vector<float> sar_ref(const std::vector<float> &high,
         std::vector<float> linearreg_angle_ref(const std::vector<float> &in,
                                                int period) {
           return run_linearreg_python(in, period, "LINEARREG_ANGLE");
+        }
+
+        std::vector<float> tsf_ref(const std::vector<float> &in, int period) {
+          return run_linearreg_python(in, period, "TSF");
         }
 
         std::vector<float> plus_dm_ref(const std::vector<float> &high,

--- a/tests/cpp/test_utils.hpp
+++ b/tests/cpp/test_utils.hpp
@@ -50,10 +50,14 @@ std::vector<float> avgprice_ref(const std::vector<float>& open,
                                 const std::vector<float>& high,
                                 const std::vector<float>& low,
                                 const std::vector<float>& close);
+std::vector<float> typprice_ref(const std::vector<float>& high,
+                                const std::vector<float>& low,
+                                const std::vector<float>& close);
 std::vector<float> linearreg_ref(const std::vector<float>& in, int period);
 std::vector<float> linearreg_slope_ref(const std::vector<float>& in, int period);
 std::vector<float> linearreg_intercept_ref(const std::vector<float>& in, int period);
 std::vector<float> linearreg_angle_ref(const std::vector<float>& in, int period);
+std::vector<float> tsf_ref(const std::vector<float>& in, int period);
 std::vector<float> plus_dm_ref(const std::vector<float>& high,
                                const std::vector<float>& low, int period);
 std::vector<float> minus_dm_ref(const std::vector<float>& high,

--- a/tests/cpp/test_var.cpp
+++ b/tests/cpp/test_var.cpp
@@ -1,0 +1,28 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+TEST(Tacuda, VAR) {
+  const int N = 100;
+  std::vector<float> x(N);
+  for (int i = 0; i < N; ++i)
+    x[i] = std::cos(0.1f * i);
+  std::vector<float> out(N, 0.0f), ref(N, std::numeric_limits<float>::quiet_NaN());
+  int p = 5;
+  ctStatus_t rc = ct_var(x.data(), out.data(), N, p);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_var failed";
+  for (int i = p - 1; i < N; ++i) {
+    float mean = 0.0f;
+    for (int j = 0; j < p; ++j)
+      mean += x[i - j];
+    mean /= p;
+    float sumsq = 0.0f;
+    for (int j = 0; j < p; ++j) {
+      float d = x[i - j] - mean;
+      sumsq += d * d;
+    }
+    ref[i] = sumsq / p;
+  }
+  expect_approx_equal(out, ref);
+  for (int i = 0; i < p - 1; ++i)
+    EXPECT_TRUE(std::isnan(out[i])) << "expected NaN at head " << i;
+}


### PR DESCRIPTION
## Summary
- add CUDA kernels for time series forecast (TSF), typical price, and variance
- expose new indicators through C API and build system
- cover added functionality with unit tests

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d26d57608329bd73eb8d3cec1948