### PR TITLE
Add candlestick pattern indicators with utilities and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,11 @@ set(INDICATOR_SOURCES
     src/indicators/TSF.cu
     src/indicators/TypPrice.cu
     src/indicators/VAR.cu
+    src/indicators/Doji.cu
+    src/indicators/Hammer.cu
+    src/indicators/InvertedHammer.cu
+    src/indicators/BullishEngulfing.cu
+    src/indicators/BearishEngulfing.cu
 )
 
 add_library(tacuda SHARED

--- a/include/indicators/BearishEngulfing.h
+++ b/include/indicators/BearishEngulfing.h
@@ -1,0 +1,14 @@
+#ifndef BEARISHENGULFING_H
+#define BEARISHENGULFING_H
+
+#include "Indicator.h"
+
+class BearishEngulfing : public Indicator {
+public:
+    BearishEngulfing() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/BullishEngulfing.h
+++ b/include/indicators/BullishEngulfing.h
@@ -1,0 +1,14 @@
+#ifndef BULLISHENGULFING_H
+#define BULLISHENGULFING_H
+
+#include "Indicator.h"
+
+class BullishEngulfing : public Indicator {
+public:
+    BullishEngulfing() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/Doji.h
+++ b/include/indicators/Doji.h
@@ -1,0 +1,16 @@
+#ifndef DOJI_H
+#define DOJI_H
+
+#include "Indicator.h"
+
+class Doji : public Indicator {
+public:
+    explicit Doji(float threshold = 0.1f);
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+private:
+    float threshold;
+};
+
+#endif

--- a/include/indicators/Hammer.h
+++ b/include/indicators/Hammer.h
@@ -1,0 +1,14 @@
+#ifndef HAMMER_H
+#define HAMMER_H
+
+#include "Indicator.h"
+
+class Hammer : public Indicator {
+public:
+    Hammer() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/InvertedHammer.h
+++ b/include/indicators/InvertedHammer.h
@@ -1,0 +1,14 @@
+#ifndef INVERTEDHAMMER_H
+#define INVERTEDHAMMER_H
+
+#include "Indicator.h"
+
+class InvertedHammer : public Indicator {
+public:
+    InvertedHammer() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -182,6 +182,23 @@ CTAPI_EXPORT ctStatus_t ct_beta(const float *host_x, const float *host_y,
 CTAPI_EXPORT ctStatus_t ct_bop(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_doji(const float *host_open, const float *host_high,
+                                    const float *host_low, const float *host_close,
+                                    float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_hammer(const float *host_open, const float *host_high,
+                                      const float *host_low, const float *host_close,
+                                      float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_inverted_hammer(const float *host_open,
+                                               const float *host_high,
+                                               const float *host_low,
+                                               const float *host_close,
+                                               float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_bullish_engulfing(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_bearish_engulfing(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_cmo(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_correl(const float *host_x, const float *host_y,

--- a/include/utils/CandleUtils.h
+++ b/include/utils/CandleUtils.h
@@ -1,0 +1,46 @@
+#ifndef CANDLEUTILS_H
+#define CANDLEUTILS_H
+
+#include <cmath>
+
+__host__ __device__ inline float real_body(float open, float close) {
+    return fabsf(close - open);
+}
+
+__host__ __device__ inline float upper_shadow(float high, float open, float close) {
+    return high - fmaxf(open, close);
+}
+
+__host__ __device__ inline float lower_shadow(float low, float open, float close) {
+    return fminf(open, close) - low;
+}
+
+__host__ __device__ inline bool is_doji(float open, float high, float low, float close, float threshold = 0.1f) {
+    float range = high - low;
+    if (range <= 0.0f) return false;
+    return real_body(open, close) / range <= threshold;
+}
+
+__host__ __device__ inline bool is_hammer(float open, float high, float low, float close) {
+    float body = real_body(open, close);
+    float upper = upper_shadow(high, open, close);
+    float lower = lower_shadow(low, open, close);
+    return lower >= 2.0f * body && upper <= body;
+}
+
+__host__ __device__ inline bool is_inverted_hammer(float open, float high, float low, float close) {
+    float body = real_body(open, close);
+    float upper = upper_shadow(high, open, close);
+    float lower = lower_shadow(low, open, close);
+    return upper >= 2.0f * body && lower <= body;
+}
+
+__host__ __device__ inline bool is_bullish_engulfing(float prevOpen, float prevClose, float open, float close) {
+    return close > open && prevClose < prevOpen && open <= prevClose && close >= prevOpen;
+}
+
+__host__ __device__ inline bool is_bearish_engulfing(float prevOpen, float prevClose, float open, float close) {
+    return close < open && prevClose > prevOpen && open >= prevClose && close <= prevOpen;
+}
+
+#endif

--- a/src/indicators/BearishEngulfing.cu
+++ b/src/indicators/BearishEngulfing.cu
@@ -1,0 +1,34 @@
+#include <indicators/BearishEngulfing.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void bearishEngulfingKernel(const float* __restrict__ open,
+                                       const float* __restrict__ high,
+                                       const float* __restrict__ low,
+                                       const float* __restrict__ close,
+                                       float* __restrict__ output,
+                                       int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 0 && idx < size) {
+        output[idx] = is_bearish_engulfing(open[idx - 1], close[idx - 1],
+                                           open[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void BearishEngulfing::calculate(const float* open, const float* high, const float* low,
+                                 const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    bearishEngulfingKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void BearishEngulfing::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/BullishEngulfing.cu
+++ b/src/indicators/BullishEngulfing.cu
@@ -1,0 +1,34 @@
+#include <indicators/BullishEngulfing.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void bullishEngulfingKernel(const float* __restrict__ open,
+                                       const float* __restrict__ high,
+                                       const float* __restrict__ low,
+                                       const float* __restrict__ close,
+                                       float* __restrict__ output,
+                                       int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 0 && idx < size) {
+        output[idx] = is_bullish_engulfing(open[idx - 1], close[idx - 1],
+                                           open[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void BullishEngulfing::calculate(const float* open, const float* high, const float* low,
+                                 const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    bullishEngulfingKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void BullishEngulfing::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/Doji.cu
+++ b/src/indicators/Doji.cu
@@ -1,0 +1,35 @@
+#include <indicators/Doji.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void dojiKernel(const float* __restrict__ open,
+                           const float* __restrict__ high,
+                           const float* __restrict__ low,
+                           const float* __restrict__ close,
+                           float* __restrict__ output,
+                           int size, float threshold) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        output[idx] = is_doji(open[idx], high[idx], low[idx], close[idx], threshold) ? 1.0f : 0.0f;
+    }
+}
+
+Doji::Doji(float threshold) : threshold(threshold) {}
+
+void Doji::calculate(const float* open, const float* high, const float* low,
+                     const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    dojiKernel<<<grid, block>>>(open, high, low, close, output, size, threshold);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void Doji::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/Hammer.cu
+++ b/src/indicators/Hammer.cu
@@ -1,0 +1,33 @@
+#include <indicators/Hammer.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void hammerKernel(const float* __restrict__ open,
+                             const float* __restrict__ high,
+                             const float* __restrict__ low,
+                             const float* __restrict__ close,
+                             float* __restrict__ output,
+                             int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        output[idx] = is_hammer(open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void Hammer::calculate(const float* open, const float* high, const float* low,
+                       const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    hammerKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void Hammer::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/InvertedHammer.cu
+++ b/src/indicators/InvertedHammer.cu
@@ -1,0 +1,33 @@
+#include <indicators/InvertedHammer.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void invertedHammerKernel(const float* __restrict__ open,
+                                     const float* __restrict__ high,
+                                     const float* __restrict__ low,
+                                     const float* __restrict__ close,
+                                     float* __restrict__ output,
+                                     int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        output[idx] = is_inverted_hammer(open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void InvertedHammer::calculate(const float* open, const float* high, const float* low,
+                               const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    invertedHammerKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void InvertedHammer::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}

--- a/tests/cpp/test_cdl_bearish_engulfing.cpp
+++ b/tests/cpp/test_cdl_bearish_engulfing.cpp
@@ -1,0 +1,21 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLBearishEngulfing) {
+  const int N = 4;
+  std::vector<float> open{10.0f, 10.5f, 10.9f, 10.8f};
+  std::vector<float> high{10.4f, 11.0f, 11.1f, 11.0f};
+  std::vector<float> low{9.8f, 10.4f, 10.0f, 10.5f};
+  std::vector<float> close{10.2f, 10.8f, 10.2f, 10.6f};
+  std::vector<float> out(N);
+  std::vector<float> ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_bearish_engulfing(open.data(), high.data(), low.data(),
+                                           close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_bearish_engulfing failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0])) << "expected NaN at head 0";
+}

--- a/tests/cpp/test_cdl_bullish_engulfing.cpp
+++ b/tests/cpp/test_cdl_bullish_engulfing.cpp
@@ -1,0 +1,21 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLBullishEngulfing) {
+  const int N = 4;
+  std::vector<float> open{10.0f, 9.5f, 9.1f, 9.3f};
+  std::vector<float> high{10.2f, 9.7f, 9.9f, 9.5f};
+  std::vector<float> low{9.7f, 9.1f, 9.0f, 8.9f};
+  std::vector<float> close{9.8f, 9.2f, 9.8f, 9.1f};
+  std::vector<float> out(N);
+  std::vector<float> ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_bullish_engulfing(open.data(), high.data(), low.data(),
+                                           close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_bullish_engulfing failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0])) << "expected NaN at head 0";
+}

--- a/tests/cpp/test_cdl_doji.cpp
+++ b/tests/cpp/test_cdl_doji.cpp
@@ -1,0 +1,18 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLDoji) {
+  const int N = 5;
+  std::vector<float> open{1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+  std::vector<float> high{1.2f, 2.2f, 3.2f, 4.2f, 5.2f};
+  std::vector<float> low{0.8f, 1.8f, 2.8f, 3.8f, 4.8f};
+  std::vector<float> close{1.1f, 2.1f, 3.01f, 4.3f, 4.9f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_doji(open.data(), high.data(), low.data(), close.data(),
+                              out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_doji failed";
+  expect_approx_equal(out, ref);
+}

--- a/tests/cpp/test_cdl_hammer.cpp
+++ b/tests/cpp/test_cdl_hammer.cpp
@@ -1,0 +1,18 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLHammer) {
+  const int N = 4;
+  std::vector<float> open{1.0f, 2.0f, 3.0f, 4.0f};
+  std::vector<float> high{1.3f, 2.08f, 3.5f, 4.3f};
+  std::vector<float> low{0.9f, 1.5f, 2.9f, 3.5f};
+  std::vector<float> close{1.2f, 2.05f, 3.4f, 3.9f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[1] = 1.0f;
+  ctStatus_t rc = ct_cdl_hammer(open.data(), high.data(), low.data(), close.data(),
+                                out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_hammer failed";
+  expect_approx_equal(out, ref);
+}

--- a/tests/cpp/test_cdl_inverted_hammer.cpp
+++ b/tests/cpp/test_cdl_inverted_hammer.cpp
@@ -1,0 +1,18 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLInvertedHammer) {
+  const int N = 3;
+  std::vector<float> open{1.0f, 2.0f, 3.0f};
+  std::vector<float> high{1.2f, 2.7f, 3.4f};
+  std::vector<float> low{0.8f, 1.98f, 2.9f};
+  std::vector<float> close{1.1f, 2.05f, 3.2f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[1] = 1.0f;
+  ctStatus_t rc = ct_cdl_inverted_hammer(open.data(), high.data(), low.data(),
+                                         close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_inverted_hammer failed";
+  expect_approx_equal(out, ref);
+}


### PR DESCRIPTION
## Summary
- implement candlestick utility helpers for body and shadow measurements
- add Doji, Hammer, Inverted Hammer, Bullish Engulfing and Bearish Engulfing CUDA indicators
- expose new ct_cdl_* APIs and tests for each pattern

## Testing
- `cmake ..` *(fails: target_compile_features no known features for CXX compiler "GNU" version 13.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d4a80fbc83299bdb974f19cdb51b