### PR TITLE
Expose candlestick pattern detectors in Python API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,11 @@ set(INDICATOR_SOURCES
     src/indicators/AdvanceBlock.cu
     src/indicators/BeltHold.cu
     src/indicators/Breakaway.cu
+    src/indicators/TwoCrows.cu
+    src/indicators/ThreeBlackCrows.cu
+    src/indicators/ThreeInside.cu
+    src/indicators/ThreeLineStrike.cu
+    src/indicators/ThreeStarsInSouth.cu
 )
 
 add_library(tacuda SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ set(INDICATOR_SOURCES
     src/indicators/InvertedHammer.cu
     src/indicators/BullishEngulfing.cu
     src/indicators/BearishEngulfing.cu
+    src/indicators/ThreeWhiteSoldiers.cu
+    src/indicators/AbandonedBaby.cu
+    src/indicators/AdvanceBlock.cu
+    src/indicators/BeltHold.cu
+    src/indicators/Breakaway.cu
 )
 
 add_library(tacuda SHARED

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It provides a **stable C API**, **Python bindings** (pybind11), and a **C# bindi
 ## Features
 
 - ⚙️ **Indicators**: `SMA` implemented; the framework is ready for `EMA`, `RSI`, `MACD`, `BBANDS`, `WMA`, `STDDEV`, `MIN/MAX`, etc.
-- 🕯️ **Candlestick patterns**: Doji, Hammer, Inverted Hammer, Bullish Engulfing, Bearish Engulfing.
+ - 🕯️ **Candlestick patterns**: Doji, Hammer, Inverted Hammer, Bullish Engulfing, Bearish Engulfing, Three White Soldiers, Abandoned Baby, Advance Block, Belt Hold, Breakaway.
 - 🧩 **TA-style API**: procedural calls by indicator name with a unified dispatcher.
 - 🧱 **Stable C interface**: `extern "C"` functions (`tacuda_sma_host`, `tacuda_run_indicator_host_c`) with a fixed ABI.
 - 🐍 **Python bindings**: `tacuda.sma()` and a generic `tacuda.run()`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It provides a **stable C API**, **Python bindings** (pybind11), and a **C# bindi
 ## Features
 
 - ⚙️ **Indicators**: `SMA` implemented; the framework is ready for `EMA`, `RSI`, `MACD`, `BBANDS`, `WMA`, `STDDEV`, `MIN/MAX`, etc.
- - 🕯️ **Candlestick patterns**: Doji, Hammer, Inverted Hammer, Bullish Engulfing, Bearish Engulfing, Three White Soldiers, Abandoned Baby, Advance Block, Belt Hold, Breakaway.
+ - 🕯️ **Candlestick patterns**: Doji, Hammer, Inverted Hammer, Bullish Engulfing, Bearish Engulfing, Three White Soldiers, Abandoned Baby, Advance Block, Belt Hold, Breakaway, Two Crows, Three Black Crows, Three Inside, Three Line Strike, Three Stars In South.
 - 🧩 **TA-style API**: procedural calls by indicator name with a unified dispatcher.
 - 🧱 **Stable C interface**: `extern "C"` functions (`tacuda_sma_host`, `tacuda_run_indicator_host_c`) with a fixed ABI.
 - 🐍 **Python bindings**: `tacuda.sma()` and a generic `tacuda.run()`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It provides a **stable C API**, **Python bindings** (pybind11), and a **C# bindi
 ## Features
 
 - ⚙️ **Indicators**: `SMA` implemented; the framework is ready for `EMA`, `RSI`, `MACD`, `BBANDS`, `WMA`, `STDDEV`, `MIN/MAX`, etc.
+- 🕯️ **Candlestick patterns**: Doji, Hammer, Inverted Hammer, Bullish Engulfing, Bearish Engulfing.
 - 🧩 **TA-style API**: procedural calls by indicator name with a unified dispatcher.
 - 🧱 **Stable C interface**: `extern "C"` functions (`tacuda_sma_host`, `tacuda_run_indicator_host_c`) with a fixed ABI.
 - 🐍 **Python bindings**: `tacuda.sma()` and a generic `tacuda.run()`.

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -159,6 +159,26 @@ _lib.ct_cdl_breakaway.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER
                                   ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
                                   ctypes.POINTER(ctypes.c_float), ctypes.c_int]
 _lib.ct_cdl_breakaway.restype  = ctypes.c_int
+_lib.ct_cdl_two_crows.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_two_crows.restype  = ctypes.c_int
+_lib.ct_cdl_three_black_crows.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_three_black_crows.restype  = ctypes.c_int
+_lib.ct_cdl_three_inside.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                     ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                     ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_three_inside.restype  = ctypes.c_int
+_lib.ct_cdl_three_line_strike.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_three_line_strike.restype  = ctypes.c_int
+_lib.ct_cdl_three_stars_in_south.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                             ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                             ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_three_stars_in_south.restype  = ctypes.c_int
 
 def _as_float_ptr(arr):
     import numpy as np
@@ -548,6 +568,101 @@ def cdl_breakaway(open, high, low, close):
         raise RuntimeError("ct_cdl_breakaway failed")
     return out
 
+def cdl_two_crows(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_two_crows(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_two_crows failed")
+    return out
+
+def cdl_three_black_crows(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_three_black_crows(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_three_black_crows failed")
+    return out
+
+def cdl_three_inside(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_three_inside(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_three_inside failed")
+    return out
+
+def cdl_three_line_strike(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_three_line_strike(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_three_line_strike failed")
+    return out
+
+def cdl_three_stars_in_south(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_three_stars_in_south(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_three_stars_in_south failed")
+    return out
+
 def trange(high, low, close):
     import numpy as np
     high = np.asarray(high, dtype=np.float32)
@@ -636,6 +751,11 @@ __all__ = [
     "cdl_advance_block",
     "cdl_belt_hold",
     "cdl_breakaway",
+    "cdl_two_crows",
+    "cdl_three_black_crows",
+    "cdl_three_inside",
+    "cdl_three_line_strike",
+    "cdl_three_stars_in_south",
     "trange",
     "summation",
     "t3",

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -139,6 +139,26 @@ _lib.ct_cdl_bearish_engulfing.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes
                                           ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
                                           ctypes.POINTER(ctypes.c_float), ctypes.c_int]
 _lib.ct_cdl_bearish_engulfing.restype  = ctypes.c_int
+_lib.ct_cdl_three_white_soldiers.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                             ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                             ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_three_white_soldiers.restype  = ctypes.c_int
+_lib.ct_cdl_abandoned_baby.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                       ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                       ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_abandoned_baby.restype  = ctypes.c_int
+_lib.ct_cdl_advance_block.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                      ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                      ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_advance_block.restype  = ctypes.c_int
+_lib.ct_cdl_belt_hold.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_belt_hold.restype  = ctypes.c_int
+_lib.ct_cdl_breakaway.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_breakaway.restype  = ctypes.c_int
 
 def _as_float_ptr(arr):
     import numpy as np
@@ -433,6 +453,101 @@ def cdl_bearish_engulfing(open, high, low, close):
         raise RuntimeError("ct_cdl_bearish_engulfing failed")
     return out
 
+def cdl_three_white_soldiers(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_three_white_soldiers(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_three_white_soldiers failed")
+    return out
+
+def cdl_abandoned_baby(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_abandoned_baby(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_abandoned_baby failed")
+    return out
+
+def cdl_advance_block(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_advance_block(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_advance_block failed")
+    return out
+
+def cdl_belt_hold(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_belt_hold(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_belt_hold failed")
+    return out
+
+def cdl_breakaway(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_breakaway(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_breakaway failed")
+    return out
+
 def trange(high, low, close):
     import numpy as np
     high = np.asarray(high, dtype=np.float32)
@@ -516,6 +631,11 @@ __all__ = [
     "cdl_inverted_hammer",
     "cdl_bullish_engulfing",
     "cdl_bearish_engulfing",
+    "cdl_three_white_soldiers",
+    "cdl_abandoned_baby",
+    "cdl_advance_block",
+    "cdl_belt_hold",
+    "cdl_breakaway",
     "trange",
     "summation",
     "t3",

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -119,6 +119,26 @@ _lib.ct_trima.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.
 _lib.ct_trima.restype  = ctypes.c_int
 _lib.ct_stochrsi.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float), ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
 _lib.ct_stochrsi.restype  = ctypes.c_int
+_lib.ct_cdl_doji.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                              ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                              ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_doji.restype  = ctypes.c_int
+_lib.ct_cdl_hammer.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_hammer.restype  = ctypes.c_int
+_lib.ct_cdl_inverted_hammer.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                        ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                        ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_inverted_hammer.restype  = ctypes.c_int
+_lib.ct_cdl_bullish_engulfing.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_bullish_engulfing.restype  = ctypes.c_int
+_lib.ct_cdl_bearish_engulfing.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_bearish_engulfing.restype  = ctypes.c_int
 
 def _as_float_ptr(arr):
     import numpy as np
@@ -316,6 +336,101 @@ def obv(price, volume):
     rc = _lib.ct_obv(pp, pv, po, price.size)
     if rc != 0:
         raise RuntimeError("ct_obv failed")
+    return out
+
+def cdl_doji(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_doji(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_doji failed")
+    return out
+
+def cdl_hammer(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_hammer(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_hammer failed")
+    return out
+
+def cdl_inverted_hammer(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_inverted_hammer(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_inverted_hammer failed")
+    return out
+
+def cdl_bullish_engulfing(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_bullish_engulfing(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_bullish_engulfing failed")
+    return out
+
+def cdl_bearish_engulfing(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_bearish_engulfing(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_bearish_engulfing failed")
     return out
 
 def trange(high, low, close):

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -495,3 +495,30 @@ def stochrsi(x, rsi_period, k_period, d_period):
     if rc != 0:
         raise RuntimeError("ct_stochrsi failed")
     return k, d
+
+
+__all__ = [
+    "sma",
+    "wma",
+    "momentum",
+    "macd_line",
+    "rsi",
+    "atr",
+    "stochastic",
+    "cci",
+    "adx",
+    "sar",
+    "aroon",
+    "ultosc",
+    "obv",
+    "cdl_doji",
+    "cdl_hammer",
+    "cdl_inverted_hammer",
+    "cdl_bullish_engulfing",
+    "cdl_bearish_engulfing",
+    "trange",
+    "summation",
+    "t3",
+    "trima",
+    "stochrsi",
+]

--- a/include/indicators/AbandonedBaby.h
+++ b/include/indicators/AbandonedBaby.h
@@ -1,0 +1,15 @@
+#ifndef ABANDONEDBABY_H
+#define ABANDONEDBABY_H
+
+#include "Indicator.h"
+
+class AbandonedBaby : public Indicator {
+public:
+    AbandonedBaby() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/AdvanceBlock.h
+++ b/include/indicators/AdvanceBlock.h
@@ -1,0 +1,15 @@
+#ifndef ADVANCEBLOCK_H
+#define ADVANCEBLOCK_H
+
+#include "Indicator.h"
+
+class AdvanceBlock : public Indicator {
+public:
+    AdvanceBlock() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/BeltHold.h
+++ b/include/indicators/BeltHold.h
@@ -1,0 +1,15 @@
+#ifndef BELTHOLD_H
+#define BELTHOLD_H
+
+#include "Indicator.h"
+
+class BeltHold : public Indicator {
+public:
+    BeltHold() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/Breakaway.h
+++ b/include/indicators/Breakaway.h
@@ -1,0 +1,15 @@
+#ifndef BREAKAWAY_H
+#define BREAKAWAY_H
+
+#include "Indicator.h"
+
+class Breakaway : public Indicator {
+public:
+    Breakaway() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/ThreeBlackCrows.h
+++ b/include/indicators/ThreeBlackCrows.h
@@ -1,0 +1,15 @@
+#ifndef THREEBLACKCROWS_H
+#define THREEBLACKCROWS_H
+
+#include "Indicator.h"
+
+class ThreeBlackCrows : public Indicator {
+public:
+    ThreeBlackCrows() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/ThreeInside.h
+++ b/include/indicators/ThreeInside.h
@@ -1,0 +1,15 @@
+#ifndef THREEINSIDE_H
+#define THREEINSIDE_H
+
+#include "Indicator.h"
+
+class ThreeInside : public Indicator {
+public:
+    ThreeInside() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/ThreeLineStrike.h
+++ b/include/indicators/ThreeLineStrike.h
@@ -1,0 +1,15 @@
+#ifndef THREELINESTRIKE_H
+#define THREELINESTRIKE_H
+
+#include "Indicator.h"
+
+class ThreeLineStrike : public Indicator {
+public:
+    ThreeLineStrike() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/ThreeStarsInSouth.h
+++ b/include/indicators/ThreeStarsInSouth.h
@@ -1,0 +1,15 @@
+#ifndef THREESTARSINSOUTH_H
+#define THREESTARSINSOUTH_H
+
+#include "Indicator.h"
+
+class ThreeStarsInSouth : public Indicator {
+public:
+    ThreeStarsInSouth() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/ThreeWhiteSoldiers.h
+++ b/include/indicators/ThreeWhiteSoldiers.h
@@ -1,0 +1,15 @@
+#ifndef THREEWHITESOLDIERS_H
+#define THREEWHITESOLDIERS_H
+
+#include "Indicator.h"
+
+class ThreeWhiteSoldiers : public Indicator {
+public:
+    ThreeWhiteSoldiers() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/indicators/TwoCrows.h
+++ b/include/indicators/TwoCrows.h
@@ -1,0 +1,15 @@
+#ifndef TWOCROWS_H
+#define TWOCROWS_H
+
+#include "Indicator.h"
+
+class TwoCrows : public Indicator {
+public:
+    TwoCrows() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size) noexcept(false);
+    void calculate(const float* input, float* output, int size) noexcept(false) override;
+};
+
+#endif
+

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -214,6 +214,21 @@ CTAPI_EXPORT ctStatus_t ct_cdl_belt_hold(
 CTAPI_EXPORT ctStatus_t ct_cdl_breakaway(
     const float *host_open, const float *host_high, const float *host_low,
     const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_two_crows(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_black_crows(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_inside(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_line_strike(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_stars_in_south(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_cmo(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_correl(const float *host_x, const float *host_y,

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -199,6 +199,21 @@ CTAPI_EXPORT ctStatus_t ct_cdl_bullish_engulfing(
 CTAPI_EXPORT ctStatus_t ct_cdl_bearish_engulfing(
     const float *host_open, const float *host_high, const float *host_low,
     const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_white_soldiers(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_abandoned_baby(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_advance_block(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_belt_hold(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_breakaway(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_cmo(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_correl(const float *host_x, const float *host_y,

--- a/include/utils/CandleUtils.h
+++ b/include/utils/CandleUtils.h
@@ -43,4 +43,57 @@ __host__ __device__ inline bool is_bearish_engulfing(float prevOpen, float prevC
     return close < open && prevClose > prevOpen && open >= prevClose && close <= prevOpen;
 }
 
+__host__ __device__ inline bool is_three_white_soldiers(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3) {
+    return c1 > o1 && c2 > o2 && c3 > o3 &&
+           o2 >= o1 && o2 <= c1 &&
+           o3 >= o2 && o3 <= c2 &&
+           c1 < c2 && c2 < c3;
+}
+
+__host__ __device__ inline bool is_abandoned_baby(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3) {
+    bool bearish1 = c1 < o1;
+    bool doji2 = is_doji(o2, h2, l2, c2);
+    bool bullish3 = c3 > o3;
+    bool gap1 = h2 < l1;
+    bool gap2 = l3 > h2;
+    return bearish1 && doji2 && bullish3 && gap1 && gap2;
+}
+
+__host__ __device__ inline bool is_advance_block(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3) {
+    if (!(c1 > o1 && c2 > o2 && c3 > o3)) return false;
+    if (!(o2 >= o1 && o2 <= c1 && o3 >= o2 && o3 <= c2)) return false;
+    float b1 = c1 - o1;
+    float b2 = c2 - o2;
+    float b3 = c3 - o3;
+    if (!(b1 > b2 && b2 > b3)) return false;
+    return true;
+}
+
+__host__ __device__ inline bool is_belt_hold(float open, float high, float low, float close) {
+    float body = fabsf(close - open);
+    float range = high - low;
+    return open == low && close > open && body > range * 0.5f;
+}
+
+__host__ __device__ inline bool is_breakaway(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3,
+    float o4, float h4, float l4, float c4,
+    float o5, float h5, float l5, float c5) {
+    if (!(c1 < o1 && c2 < o2 && c3 < o3 && c4 < o4 && c5 > o5)) return false;
+    if (!(o2 < c1 && o3 < c2 && o4 < c3)) return false;
+    if (!(c5 > o1)) return false;
+    return true;
+}
+
 #endif

--- a/include/utils/CandleUtils.h
+++ b/include/utils/CandleUtils.h
@@ -96,4 +96,58 @@ __host__ __device__ inline bool is_breakaway(
     return true;
 }
 
+__host__ __device__ inline bool is_two_crows(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3) {
+    return c1 > o1 && c2 < o2 && c3 < o3 &&
+           o2 > c1 && c2 > c1 &&
+           o3 < o2 && o3 > c2 &&
+           c3 < c2 && c3 > o1 && c3 < c1;
+}
+
+__host__ __device__ inline bool is_three_black_crows(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3) {
+    return c1 < o1 && c2 < o2 && c3 < o3 &&
+           o2 <= o1 && o2 >= c1 &&
+           o3 <= o2 && o3 >= c2 &&
+           c1 > c2 && c2 > c3;
+}
+
+__host__ __device__ inline bool is_three_inside(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3) {
+    return c1 > o1 && c2 < o2 &&
+           o2 >= o1 && c2 <= c1 && o2 <= c1 && c2 >= o1 &&
+           c3 > o3 && c3 > c1;
+}
+
+__host__ __device__ inline bool is_three_line_strike(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3,
+    float o4, float h4, float l4, float c4) {
+    bool firstThree = c1 > o1 && c2 > o2 && c3 > o3 &&
+                      o2 >= o1 && o2 <= c1 &&
+                      o3 >= o2 && o3 <= c2 &&
+                      c1 < c2 && c2 < c3;
+    bool fourth = c4 < o4 && o4 >= c3 && c4 < o1;
+    return firstThree && fourth;
+}
+
+__host__ __device__ inline bool is_three_stars_in_south(
+    float o1, float h1, float l1, float c1,
+    float o2, float h2, float l2, float c2,
+    float o3, float h3, float l3, float c3) {
+    float ls1 = lower_shadow(l1, o1, c1);
+    float ls2 = lower_shadow(l2, o2, c2);
+    float ls3 = lower_shadow(l3, o3, c3);
+    return c1 < o1 && c2 < o2 && c3 < o3 &&
+           c1 > c2 && c2 > c3 &&
+           ls1 > ls2 && ls2 > ls3;
+}
+
 #endif

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -28,6 +28,11 @@
 #include <indicators/AdvanceBlock.h>
 #include <indicators/BeltHold.h>
 #include <indicators/Breakaway.h>
+#include <indicators/TwoCrows.h>
+#include <indicators/ThreeBlackCrows.h>
+#include <indicators/ThreeInside.h>
+#include <indicators/ThreeLineStrike.h>
+#include <indicators/ThreeStarsInSouth.h>
 #include <indicators/CCI.h>
 #include <indicators/CMO.h>
 #include <indicators/Change.h>
@@ -2086,6 +2091,56 @@ ctStatus_t ct_cdl_breakaway(const float *host_open,
                             const float *host_close,
                             float *host_output, int size) {
   Breakaway ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_two_crows(const float *host_open,
+                            const float *host_high,
+                            const float *host_low,
+                            const float *host_close,
+                            float *host_output, int size) {
+  TwoCrows ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_three_black_crows(const float *host_open,
+                                    const float *host_high,
+                                    const float *host_low,
+                                    const float *host_close,
+                                    float *host_output, int size) {
+  ThreeBlackCrows ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_three_inside(const float *host_open,
+                               const float *host_high,
+                               const float *host_low,
+                               const float *host_close,
+                               float *host_output, int size) {
+  ThreeInside ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_three_line_strike(const float *host_open,
+                                    const float *host_high,
+                                    const float *host_low,
+                                    const float *host_close,
+                                    float *host_output, int size) {
+  ThreeLineStrike ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_three_stars_in_south(const float *host_open,
+                                       const float *host_high,
+                                       const float *host_low,
+                                       const float *host_close,
+                                       float *host_output, int size) {
+  ThreeStarsInSouth ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -23,6 +23,11 @@
 #include <indicators/Doji.h>
 #include <indicators/Hammer.h>
 #include <indicators/InvertedHammer.h>
+#include <indicators/ThreeWhiteSoldiers.h>
+#include <indicators/AbandonedBaby.h>
+#include <indicators/AdvanceBlock.h>
+#include <indicators/BeltHold.h>
+#include <indicators/Breakaway.h>
 #include <indicators/CCI.h>
 #include <indicators/CMO.h>
 #include <indicators/Change.h>
@@ -2031,6 +2036,56 @@ ctStatus_t ct_cdl_bearish_engulfing(const float *host_open,
                                     const float *host_close,
                                     float *host_output, int size) {
   BearishEngulfing ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_three_white_soldiers(const float *host_open,
+                                       const float *host_high,
+                                       const float *host_low,
+                                       const float *host_close,
+                                       float *host_output, int size) {
+  ThreeWhiteSoldiers ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_abandoned_baby(const float *host_open,
+                                 const float *host_high,
+                                 const float *host_low,
+                                 const float *host_close,
+                                 float *host_output, int size) {
+  AbandonedBaby ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_advance_block(const float *host_open,
+                                const float *host_high,
+                                const float *host_low,
+                                const float *host_close,
+                                float *host_output, int size) {
+  AdvanceBlock ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_belt_hold(const float *host_open,
+                            const float *host_high,
+                            const float *host_low,
+                            const float *host_close,
+                            float *host_output, int size) {
+  BeltHold ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_breakaway(const float *host_open,
+                            const float *host_high,
+                            const float *host_low,
+                            const float *host_close,
+                            float *host_output, int size) {
+  Breakaway ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }

--- a/src/indicators/AbandonedBaby.cu
+++ b/src/indicators/AbandonedBaby.cu
@@ -1,0 +1,37 @@
+#include <indicators/AbandonedBaby.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void abandonedBabyKernel(const float* __restrict__ open,
+                                    const float* __restrict__ high,
+                                    const float* __restrict__ low,
+                                    const float* __restrict__ close,
+                                    float* __restrict__ output,
+                                    int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 1 && idx < size) {
+        output[idx] = is_abandoned_baby(
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void AbandonedBaby::calculate(const float* open, const float* high, const float* low,
+                              const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    abandonedBabyKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void AbandonedBaby::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/AdvanceBlock.cu
+++ b/src/indicators/AdvanceBlock.cu
@@ -1,0 +1,37 @@
+#include <indicators/AdvanceBlock.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void advanceBlockKernel(const float* __restrict__ open,
+                                   const float* __restrict__ high,
+                                   const float* __restrict__ low,
+                                   const float* __restrict__ close,
+                                   float* __restrict__ output,
+                                   int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 1 && idx < size) {
+        output[idx] = is_advance_block(
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void AdvanceBlock::calculate(const float* open, const float* high, const float* low,
+                             const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    advanceBlockKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void AdvanceBlock::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/BeltHold.cu
+++ b/src/indicators/BeltHold.cu
@@ -1,0 +1,34 @@
+#include <indicators/BeltHold.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void beltHoldKernel(const float* __restrict__ open,
+                               const float* __restrict__ high,
+                               const float* __restrict__ low,
+                               const float* __restrict__ close,
+                               float* __restrict__ output,
+                               int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        output[idx] = is_belt_hold(open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void BeltHold::calculate(const float* open, const float* high, const float* low,
+                         const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    beltHoldKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void BeltHold::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/Breakaway.cu
+++ b/src/indicators/Breakaway.cu
@@ -1,0 +1,39 @@
+#include <indicators/Breakaway.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void breakawayKernel(const float* __restrict__ open,
+                                const float* __restrict__ high,
+                                const float* __restrict__ low,
+                                const float* __restrict__ close,
+                                float* __restrict__ output,
+                                int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 3 && idx < size) {
+        output[idx] = is_breakaway(
+            open[idx - 4], high[idx - 4], low[idx - 4], close[idx - 4],
+            open[idx - 3], high[idx - 3], low[idx - 3], close[idx - 3],
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void Breakaway::calculate(const float* open, const float* high, const float* low,
+                          const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    breakawayKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void Breakaway::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/ThreeBlackCrows.cu
+++ b/src/indicators/ThreeBlackCrows.cu
@@ -1,0 +1,37 @@
+#include <indicators/ThreeBlackCrows.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void threeBlackCrowsKernel(const float* __restrict__ open,
+                                      const float* __restrict__ high,
+                                      const float* __restrict__ low,
+                                      const float* __restrict__ close,
+                                      float* __restrict__ output,
+                                      int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 1 && idx < size) {
+        output[idx] = is_three_black_crows(
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void ThreeBlackCrows::calculate(const float* open, const float* high, const float* low,
+                                const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    threeBlackCrowsKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void ThreeBlackCrows::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/ThreeInside.cu
+++ b/src/indicators/ThreeInside.cu
@@ -1,0 +1,37 @@
+#include <indicators/ThreeInside.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void threeInsideKernel(const float* __restrict__ open,
+                                  const float* __restrict__ high,
+                                  const float* __restrict__ low,
+                                  const float* __restrict__ close,
+                                  float* __restrict__ output,
+                                  int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 1 && idx < size) {
+        output[idx] = is_three_inside(
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void ThreeInside::calculate(const float* open, const float* high, const float* low,
+                            const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    threeInsideKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void ThreeInside::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/ThreeLineStrike.cu
+++ b/src/indicators/ThreeLineStrike.cu
@@ -1,0 +1,38 @@
+#include <indicators/ThreeLineStrike.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void threeLineStrikeKernel(const float* __restrict__ open,
+                                      const float* __restrict__ high,
+                                      const float* __restrict__ low,
+                                      const float* __restrict__ close,
+                                      float* __restrict__ output,
+                                      int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 2 && idx < size) {
+        output[idx] = is_three_line_strike(
+            open[idx - 3], high[idx - 3], low[idx - 3], close[idx - 3],
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void ThreeLineStrike::calculate(const float* open, const float* high, const float* low,
+                                const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    threeLineStrikeKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void ThreeLineStrike::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/ThreeStarsInSouth.cu
+++ b/src/indicators/ThreeStarsInSouth.cu
@@ -1,0 +1,37 @@
+#include <indicators/ThreeStarsInSouth.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void threeStarsInSouthKernel(const float* __restrict__ open,
+                                        const float* __restrict__ high,
+                                        const float* __restrict__ low,
+                                        const float* __restrict__ close,
+                                        float* __restrict__ output,
+                                        int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 1 && idx < size) {
+        output[idx] = is_three_stars_in_south(
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void ThreeStarsInSouth::calculate(const float* open, const float* high, const float* low,
+                                  const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    threeStarsInSouthKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void ThreeStarsInSouth::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/ThreeWhiteSoldiers.cu
+++ b/src/indicators/ThreeWhiteSoldiers.cu
@@ -1,0 +1,37 @@
+#include <indicators/ThreeWhiteSoldiers.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void threeWhiteSoldiersKernel(const float* __restrict__ open,
+                                         const float* __restrict__ high,
+                                         const float* __restrict__ low,
+                                         const float* __restrict__ close,
+                                         float* __restrict__ output,
+                                         int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 1 && idx < size) {
+        output[idx] = is_three_white_soldiers(
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void ThreeWhiteSoldiers::calculate(const float* open, const float* high, const float* low,
+                                   const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    threeWhiteSoldiersKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void ThreeWhiteSoldiers::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/src/indicators/TwoCrows.cu
+++ b/src/indicators/TwoCrows.cu
@@ -1,0 +1,37 @@
+#include <indicators/TwoCrows.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void twoCrowsKernel(const float* __restrict__ open,
+                               const float* __restrict__ high,
+                               const float* __restrict__ low,
+                               const float* __restrict__ close,
+                               float* __restrict__ output,
+                               int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 1 && idx < size) {
+        output[idx] = is_two_crows(
+            open[idx - 2], high[idx - 2], low[idx - 2], close[idx - 2],
+            open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+            open[idx], high[idx], low[idx], close[idx]) ? 1.0f : 0.0f;
+    }
+}
+
+void TwoCrows::calculate(const float* open, const float* high, const float* low,
+                         const float* close, float* output, int size) noexcept(false) {
+    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    twoCrowsKernel<<<grid, block>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void TwoCrows::calculate(const float* input, float* output, int size) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size);
+}
+

--- a/tests/cpp/test_cdl_abandoned_baby.cpp
+++ b/tests/cpp/test_cdl_abandoned_baby.cpp
@@ -1,0 +1,23 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLAbandonedBaby) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 8.5f, 9.2f, 9.0f, 9.0f};
+  std::vector<float> high{10.1f, 8.6f, 9.9f, 9.1f, 9.1f};
+  std::vector<float> low{8.9f, 8.4f, 9.1f, 8.9f, 8.9f};
+  std::vector<float> close{9.0f, 8.5f, 9.8f, 9.0f, 9.0f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_abandoned_baby(open.data(), high.data(), low.data(),
+                                        close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_abandoned_baby failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0])) << "expected NaN at head 0";
+  EXPECT_TRUE(std::isnan(out[1])) << "expected NaN at head 1";
+}
+

--- a/tests/cpp/test_cdl_advance_block.cpp
+++ b/tests/cpp/test_cdl_advance_block.cpp
@@ -1,0 +1,23 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLAdvanceBlock) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 10.5f, 10.9f, 10.0f, 10.0f};
+  std::vector<float> high{10.9f, 11.2f, 11.4f, 10.1f, 10.1f};
+  std::vector<float> low{9.9f, 10.4f, 10.8f, 9.9f, 9.9f};
+  std::vector<float> close{10.8f, 11.1f, 11.3f, 10.05f, 10.05f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_advance_block(open.data(), high.data(), low.data(),
+                                       close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_advance_block failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0])) << "expected NaN at head 0";
+  EXPECT_TRUE(std::isnan(out[1])) << "expected NaN at head 1";
+}
+

--- a/tests/cpp/test_cdl_belt_hold.cpp
+++ b/tests/cpp/test_cdl_belt_hold.cpp
@@ -1,0 +1,17 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+
+TEST(Tacuda, CDLBeltHold) {
+  const int N = 3;
+  std::vector<float> open{10.0f, 11.0f, 12.0f};
+  std::vector<float> high{10.8f, 11.5f, 12.5f};
+  std::vector<float> low{10.0f, 10.8f, 11.7f};
+  std::vector<float> close{10.7f, 11.2f, 12.3f};
+  std::vector<float> out(N), ref{1.0f, 0.0f, 0.0f};
+  ctStatus_t rc = ct_cdl_belt_hold(open.data(), high.data(), low.data(),
+                                   close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_belt_hold failed";
+  expect_approx_equal(out, ref);
+}
+

--- a/tests/cpp/test_cdl_breakaway.cpp
+++ b/tests/cpp/test_cdl_breakaway.cpp
@@ -1,0 +1,25 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLBreakaway) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 8.8f, 8.0f, 7.4f, 7.1f};
+  std::vector<float> high{10.1f, 8.9f, 8.1f, 7.5f, 10.3f};
+  std::vector<float> low{8.9f, 8.0f, 7.3f, 6.8f, 7.0f};
+  std::vector<float> close{9.0f, 8.2f, 7.5f, 7.0f, 10.2f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = std::numeric_limits<float>::quiet_NaN();
+  ref[3] = std::numeric_limits<float>::quiet_NaN();
+  ref[4] = 1.0f;
+  ctStatus_t rc = ct_cdl_breakaway(open.data(), high.data(), low.data(),
+                                   close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_breakaway failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[3]));
+}
+

--- a/tests/cpp/test_cdl_three_black_crows.cpp
+++ b/tests/cpp/test_cdl_three_black_crows.cpp
@@ -1,0 +1,23 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLThreeBlackCrows) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 9.5f, 9.0f, 7.6f, 7.6f};
+  std::vector<float> high{10.1f, 9.6f, 9.1f, 7.7f, 7.7f};
+  std::vector<float> low{8.9f, 8.4f, 7.4f, 7.5f, 7.5f};
+  std::vector<float> close{9.0f, 8.5f, 7.5f, 7.6f, 7.6f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_three_black_crows(open.data(), high.data(), low.data(),
+                                           close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_three_black_crows failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+}
+

--- a/tests/cpp/test_cdl_three_inside.cpp
+++ b/tests/cpp/test_cdl_three_inside.cpp
@@ -1,0 +1,23 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLThreeInside) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 11.5f, 11.3f, 12.4f, 12.3f};
+  std::vector<float> high{12.2f, 11.6f, 12.6f, 12.5f, 12.4f};
+  std::vector<float> low{9.8f, 11.1f, 11.0f, 11.9f, 11.8f};
+  std::vector<float> close{12.0f, 11.2f, 12.5f, 12.3f, 12.2f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_three_inside(open.data(), high.data(), low.data(),
+                                      close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_three_inside failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+}
+

--- a/tests/cpp/test_cdl_three_line_strike.cpp
+++ b/tests/cpp/test_cdl_three_line_strike.cpp
@@ -1,0 +1,24 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLThreeLineStrike) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 10.8f, 11.3f, 12.2f, 9.6f};
+  std::vector<float> high{11.1f, 11.6f, 12.1f, 12.3f, 9.7f};
+  std::vector<float> low{9.9f, 10.7f, 11.2f, 9.4f, 9.5f};
+  std::vector<float> close{11.0f, 11.5f, 12.0f, 9.5f, 9.6f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = std::numeric_limits<float>::quiet_NaN();
+  ref[3] = 1.0f;
+  ctStatus_t rc = ct_cdl_three_line_strike(open.data(), high.data(), low.data(),
+                                           close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_three_line_strike failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[2]));
+}
+

--- a/tests/cpp/test_cdl_three_stars_in_south.cpp
+++ b/tests/cpp/test_cdl_three_stars_in_south.cpp
@@ -1,0 +1,23 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLThreeStarsInSouth) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 8.5f, 7.8f, 7.8f, 7.8f};
+  std::vector<float> high{10.1f, 8.6f, 7.9f, 7.9f, 7.9f};
+  std::vector<float> low{6.0f, 7.0f, 7.2f, 7.7f, 7.7f};
+  std::vector<float> close{8.0f, 7.5f, 7.4f, 7.8f, 7.8f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_three_stars_in_south(open.data(), high.data(), low.data(),
+                                              close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_three_stars_in_south failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+}
+

--- a/tests/cpp/test_cdl_three_white_soldiers.cpp
+++ b/tests/cpp/test_cdl_three_white_soldiers.cpp
@@ -1,0 +1,23 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLThreeWhiteSoldiers) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 10.6f, 11.2f, 11.5f, 11.6f};
+  std::vector<float> high{10.8f, 11.4f, 12.1f, 11.6f, 11.7f};
+  std::vector<float> low{9.9f, 10.5f, 11.1f, 11.4f, 11.5f};
+  std::vector<float> close{10.7f, 11.3f, 12.0f, 11.55f, 11.55f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_three_white_soldiers(open.data(), high.data(), low.data(),
+                                              close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_three_white_soldiers failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0])) << "expected NaN at head 0";
+  EXPECT_TRUE(std::isnan(out[1])) << "expected NaN at head 1";
+}
+

--- a/tests/cpp/test_cdl_two_crows.cpp
+++ b/tests/cpp/test_cdl_two_crows.cpp
@@ -1,0 +1,23 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+#include <vector>
+#include <limits>
+
+TEST(Tacuda, CDLTwoCrows) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 12.0f, 11.8f, 11.5f, 11.5f};
+  std::vector<float> high{11.2f, 12.3f, 12.0f, 11.6f, 11.6f};
+  std::vector<float> low{9.8f, 11.4f, 10.5f, 11.4f, 11.4f};
+  std::vector<float> close{11.0f, 11.6f, 10.6f, 11.5f, 11.5f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_two_crows(open.data(), high.data(), low.data(),
+                                   close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_two_crows failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+}
+


### PR DESCRIPTION
## Summary
- add ctypes signatures for Doji, Hammer, Inverted Hammer, Bullish and Bearish Engulfing patterns
- expose Python helper functions wrapping the new candlestick pattern APIs

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Failed to find nvcc)*
- `python -m py_compile bindings/python/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d75e6c7083299a1843c0acee6b6b