### PR TITLE
Add additional candlestick pattern indicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ set(INDICATOR_SOURCES
     src/indicators/ThreeInside.cu
     src/indicators/ThreeLineStrike.cu
     src/indicators/ThreeStarsInSouth.cu
+    src/indicators/ClosingMarubozu.cu
+    src/indicators/ConcealBabySwallow.cu
+    src/indicators/CounterAttack.cu
+    src/indicators/DarkCloudCover.cu
 )
 
 add_library(tacuda SHARED

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -179,6 +179,22 @@ _lib.ct_cdl_three_stars_in_south.argtypes = [ctypes.POINTER(ctypes.c_float), cty
                                              ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
                                              ctypes.POINTER(ctypes.c_float), ctypes.c_int]
 _lib.ct_cdl_three_stars_in_south.restype  = ctypes.c_int
+_lib.ct_cdl_closing_marubozu.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                         ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                         ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_closing_marubozu.restype  = ctypes.c_int
+_lib.ct_cdl_conceal_baby_swallow.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                             ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                             ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_conceal_baby_swallow.restype  = ctypes.c_int
+_lib.ct_cdl_counterattack.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                      ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                      ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_counterattack.restype  = ctypes.c_int
+_lib.ct_cdl_dark_cloud_cover.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                         ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                         ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_dark_cloud_cover.restype  = ctypes.c_int
 
 def _as_float_ptr(arr):
     import numpy as np

--- a/include/indicators/ClosingMarubozu.h
+++ b/include/indicators/ClosingMarubozu.h
@@ -1,0 +1,14 @@
+#ifndef CLOSINGMARUBOZU_H
+#define CLOSINGMARUBOZU_H
+
+#include "Indicator.h"
+
+class ClosingMarubozu : public Indicator {
+public:
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/ConcealBabySwallow.h
+++ b/include/indicators/ConcealBabySwallow.h
@@ -1,0 +1,14 @@
+#ifndef CONCEALBABYSWALLOW_H
+#define CONCEALBABYSWALLOW_H
+
+#include "Indicator.h"
+
+class ConcealBabySwallow : public Indicator {
+public:
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/CounterAttack.h
+++ b/include/indicators/CounterAttack.h
@@ -1,0 +1,14 @@
+#ifndef COUNTERATTACK_H
+#define COUNTERATTACK_H
+
+#include "Indicator.h"
+
+class CounterAttack : public Indicator {
+public:
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/DarkCloudCover.h
+++ b/include/indicators/DarkCloudCover.h
@@ -1,0 +1,14 @@
+#ifndef DARKCLOUDCOVER_H
+#define DARKCLOUDCOVER_H
+
+#include "Indicator.h"
+
+class DarkCloudCover : public Indicator {
+public:
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -182,53 +182,95 @@ CTAPI_EXPORT ctStatus_t ct_beta(const float *host_x, const float *host_y,
 CTAPI_EXPORT ctStatus_t ct_bop(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_doji(const float *host_open, const float *host_high,
-                                    const float *host_low, const float *host_close,
-                                    float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_hammer(const float *host_open, const float *host_high,
-                                      const float *host_low, const float *host_close,
+CTAPI_EXPORT ctStatus_t ct_cdl_doji(const float *host_open,
+                                    const float *host_high,
+                                    const float *host_low,
+                                    const float *host_close, float *host_output,
+                                    int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_hammer(const float *host_open,
+                                      const float *host_high,
+                                      const float *host_low,
+                                      const float *host_close,
                                       float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_cdl_inverted_hammer(const float *host_open,
                                                const float *host_high,
                                                const float *host_low,
                                                const float *host_close,
                                                float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_bullish_engulfing(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_bearish_engulfing(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_bullish_engulfing(const float *host_open,
+                                                 const float *host_high,
+                                                 const float *host_low,
+                                                 const float *host_close,
+                                                 float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_bearish_engulfing(const float *host_open,
+                                                 const float *host_high,
+                                                 const float *host_low,
+                                                 const float *host_close,
+                                                 float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_cdl_three_white_soldiers(
     const float *host_open, const float *host_high, const float *host_low,
     const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_abandoned_baby(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_advance_block(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_belt_hold(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_breakaway(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_two_crows(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_three_black_crows(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_three_inside(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
-CTAPI_EXPORT ctStatus_t ct_cdl_three_line_strike(
-    const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_abandoned_baby(const float *host_open,
+                                              const float *host_high,
+                                              const float *host_low,
+                                              const float *host_close,
+                                              float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_advance_block(const float *host_open,
+                                             const float *host_high,
+                                             const float *host_low,
+                                             const float *host_close,
+                                             float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_belt_hold(const float *host_open,
+                                         const float *host_high,
+                                         const float *host_low,
+                                         const float *host_close,
+                                         float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_breakaway(const float *host_open,
+                                         const float *host_high,
+                                         const float *host_low,
+                                         const float *host_close,
+                                         float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_two_crows(const float *host_open,
+                                         const float *host_high,
+                                         const float *host_low,
+                                         const float *host_close,
+                                         float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_black_crows(const float *host_open,
+                                                 const float *host_high,
+                                                 const float *host_low,
+                                                 const float *host_close,
+                                                 float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_inside(const float *host_open,
+                                            const float *host_high,
+                                            const float *host_low,
+                                            const float *host_close,
+                                            float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_line_strike(const float *host_open,
+                                                 const float *host_high,
+                                                 const float *host_low,
+                                                 const float *host_close,
+                                                 float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_cdl_three_stars_in_south(
     const float *host_open, const float *host_high, const float *host_low,
     const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_closing_marubozu(const float *host_open,
+                                                const float *host_high,
+                                                const float *host_low,
+                                                const float *host_close,
+                                                float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_conceal_baby_swallow(
+    const float *host_open, const float *host_high, const float *host_low,
+    const float *host_close, float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_counterattack(const float *host_open,
+                                             const float *host_high,
+                                             const float *host_low,
+                                             const float *host_close,
+                                             float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_dark_cloud_cover(const float *host_open,
+                                                const float *host_high,
+                                                const float *host_low,
+                                                const float *host_close,
+                                                float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_cmo(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_correl(const float *host_x, const float *host_y,
@@ -247,8 +289,8 @@ CTAPI_EXPORT ctStatus_t ct_linearreg_intercept(const float *host_input,
 CTAPI_EXPORT ctStatus_t ct_linearreg_angle(const float *host_input,
                                            float *host_output, int size,
                                            int period);
-CTAPI_EXPORT ctStatus_t ct_tsf(const float *host_input,
-                               float *host_output, int size, int period);
+CTAPI_EXPORT ctStatus_t ct_tsf(const float *host_input, float *host_output,
+                               int size, int period);
 CTAPI_EXPORT ctStatus_t ct_ht_dcperiod(const float *host_input,
                                        float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_ht_dcphase(const float *host_input,

--- a/include/utils/CandleUtils.h
+++ b/include/utils/CandleUtils.h
@@ -4,150 +4,184 @@
 #include <cmath>
 
 __host__ __device__ inline float real_body(float open, float close) {
-    return fabsf(close - open);
+  return fabsf(close - open);
 }
 
-__host__ __device__ inline float upper_shadow(float high, float open, float close) {
-    return high - fmaxf(open, close);
+__host__ __device__ inline float upper_shadow(float high, float open,
+                                              float close) {
+  return high - fmaxf(open, close);
 }
 
-__host__ __device__ inline float lower_shadow(float low, float open, float close) {
-    return fminf(open, close) - low;
+__host__ __device__ inline float lower_shadow(float low, float open,
+                                              float close) {
+  return fminf(open, close) - low;
 }
 
-__host__ __device__ inline bool is_doji(float open, float high, float low, float close, float threshold = 0.1f) {
-    float range = high - low;
-    if (range <= 0.0f) return false;
-    return real_body(open, close) / range <= threshold;
+__host__ __device__ inline bool is_doji(float open, float high, float low,
+                                        float close, float threshold = 0.1f) {
+  float range = high - low;
+  if (range <= 0.0f)
+    return false;
+  return real_body(open, close) / range <= threshold;
 }
 
-__host__ __device__ inline bool is_hammer(float open, float high, float low, float close) {
-    float body = real_body(open, close);
-    float upper = upper_shadow(high, open, close);
-    float lower = lower_shadow(low, open, close);
-    return lower >= 2.0f * body && upper <= body;
+__host__ __device__ inline bool is_hammer(float open, float high, float low,
+                                          float close) {
+  float body = real_body(open, close);
+  float upper = upper_shadow(high, open, close);
+  float lower = lower_shadow(low, open, close);
+  return lower >= 2.0f * body && upper <= body;
 }
 
-__host__ __device__ inline bool is_inverted_hammer(float open, float high, float low, float close) {
-    float body = real_body(open, close);
-    float upper = upper_shadow(high, open, close);
-    float lower = lower_shadow(low, open, close);
-    return upper >= 2.0f * body && lower <= body;
+__host__ __device__ inline bool is_inverted_hammer(float open, float high,
+                                                   float low, float close) {
+  float body = real_body(open, close);
+  float upper = upper_shadow(high, open, close);
+  float lower = lower_shadow(low, open, close);
+  return upper >= 2.0f * body && lower <= body;
 }
 
-__host__ __device__ inline bool is_bullish_engulfing(float prevOpen, float prevClose, float open, float close) {
-    return close > open && prevClose < prevOpen && open <= prevClose && close >= prevOpen;
+__host__ __device__ inline bool
+is_bullish_engulfing(float prevOpen, float prevClose, float open, float close) {
+  return close > open && prevClose < prevOpen && open <= prevClose &&
+         close >= prevOpen;
 }
 
-__host__ __device__ inline bool is_bearish_engulfing(float prevOpen, float prevClose, float open, float close) {
-    return close < open && prevClose > prevOpen && open >= prevClose && close <= prevOpen;
+__host__ __device__ inline bool
+is_bearish_engulfing(float prevOpen, float prevClose, float open, float close) {
+  return close < open && prevClose > prevOpen && open >= prevClose &&
+         close <= prevOpen;
 }
 
-__host__ __device__ inline bool is_three_white_soldiers(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3) {
-    return c1 > o1 && c2 > o2 && c3 > o3 &&
-           o2 >= o1 && o2 <= c1 &&
-           o3 >= o2 && o3 <= c2 &&
-           c1 < c2 && c2 < c3;
+__host__ __device__ inline bool
+is_three_white_soldiers(float o1, float h1, float l1, float c1, float o2,
+                        float h2, float l2, float c2, float o3, float h3,
+                        float l3, float c3) {
+  return c1 > o1 && c2 > o2 && c3 > o3 && o2 >= o1 && o2 <= c1 && o3 >= o2 &&
+         o3 <= c2 && c1 < c2 && c2 < c3;
 }
 
-__host__ __device__ inline bool is_abandoned_baby(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3) {
-    bool bearish1 = c1 < o1;
-    bool doji2 = is_doji(o2, h2, l2, c2);
-    bool bullish3 = c3 > o3;
-    bool gap1 = h2 < l1;
-    bool gap2 = l3 > h2;
-    return bearish1 && doji2 && bullish3 && gap1 && gap2;
+__host__ __device__ inline bool
+is_abandoned_baby(float o1, float h1, float l1, float c1, float o2, float h2,
+                  float l2, float c2, float o3, float h3, float l3, float c3) {
+  bool bearish1 = c1 < o1;
+  bool doji2 = is_doji(o2, h2, l2, c2);
+  bool bullish3 = c3 > o3;
+  bool gap1 = h2 < l1;
+  bool gap2 = l3 > h2;
+  return bearish1 && doji2 && bullish3 && gap1 && gap2;
 }
 
-__host__ __device__ inline bool is_advance_block(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3) {
-    if (!(c1 > o1 && c2 > o2 && c3 > o3)) return false;
-    if (!(o2 >= o1 && o2 <= c1 && o3 >= o2 && o3 <= c2)) return false;
-    float b1 = c1 - o1;
-    float b2 = c2 - o2;
-    float b3 = c3 - o3;
-    if (!(b1 > b2 && b2 > b3)) return false;
-    return true;
+__host__ __device__ inline bool is_advance_block(float o1, float h1, float l1,
+                                                 float c1, float o2, float h2,
+                                                 float l2, float c2, float o3,
+                                                 float h3, float l3, float c3) {
+  if (!(c1 > o1 && c2 > o2 && c3 > o3))
+    return false;
+  if (!(o2 >= o1 && o2 <= c1 && o3 >= o2 && o3 <= c2))
+    return false;
+  float b1 = c1 - o1;
+  float b2 = c2 - o2;
+  float b3 = c3 - o3;
+  if (!(b1 > b2 && b2 > b3))
+    return false;
+  return true;
 }
 
-__host__ __device__ inline bool is_belt_hold(float open, float high, float low, float close) {
-    float body = fabsf(close - open);
-    float range = high - low;
-    return open == low && close > open && body > range * 0.5f;
+__host__ __device__ inline bool is_belt_hold(float open, float high, float low,
+                                             float close) {
+  float body = fabsf(close - open);
+  float range = high - low;
+  return open == low && close > open && body > range * 0.5f;
 }
 
-__host__ __device__ inline bool is_breakaway(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3,
-    float o4, float h4, float l4, float c4,
-    float o5, float h5, float l5, float c5) {
-    if (!(c1 < o1 && c2 < o2 && c3 < o3 && c4 < o4 && c5 > o5)) return false;
-    if (!(o2 < c1 && o3 < c2 && o4 < c3)) return false;
-    if (!(c5 > o1)) return false;
-    return true;
+__host__ __device__ inline bool
+is_breakaway(float o1, float h1, float l1, float c1, float o2, float h2,
+             float l2, float c2, float o3, float h3, float l3, float c3,
+             float o4, float h4, float l4, float c4, float o5, float h5,
+             float l5, float c5) {
+  if (!(c1 < o1 && c2 < o2 && c3 < o3 && c4 < o4 && c5 > o5))
+    return false;
+  if (!(o2 < c1 && o3 < c2 && o4 < c3))
+    return false;
+  if (!(c5 > o1))
+    return false;
+  return true;
 }
 
-__host__ __device__ inline bool is_two_crows(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3) {
-    return c1 > o1 && c2 < o2 && c3 < o3 &&
-           o2 > c1 && c2 > c1 &&
-           o3 < o2 && o3 > c2 &&
-           c3 < c2 && c3 > o1 && c3 < c1;
+__host__ __device__ inline bool is_two_crows(float o1, float h1, float l1,
+                                             float c1, float o2, float h2,
+                                             float l2, float c2, float o3,
+                                             float h3, float l3, float c3) {
+  return c1 > o1 && c2 < o2 && c3 < o3 && o2 > c1 && c2 > c1 && o3 < o2 &&
+         o3 > c2 && c3 < c2 && c3 > o1 && c3 < c1;
 }
 
-__host__ __device__ inline bool is_three_black_crows(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3) {
-    return c1 < o1 && c2 < o2 && c3 < o3 &&
-           o2 <= o1 && o2 >= c1 &&
-           o3 <= o2 && o3 >= c2 &&
-           c1 > c2 && c2 > c3;
+__host__ __device__ inline bool
+is_three_black_crows(float o1, float h1, float l1, float c1, float o2, float h2,
+                     float l2, float c2, float o3, float h3, float l3,
+                     float c3) {
+  return c1 < o1 && c2 < o2 && c3 < o3 && o2 <= o1 && o2 >= c1 && o3 <= o2 &&
+         o3 >= c2 && c1 > c2 && c2 > c3;
 }
 
-__host__ __device__ inline bool is_three_inside(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3) {
-    return c1 > o1 && c2 < o2 &&
-           o2 >= o1 && c2 <= c1 && o2 <= c1 && c2 >= o1 &&
-           c3 > o3 && c3 > c1;
+__host__ __device__ inline bool is_three_inside(float o1, float h1, float l1,
+                                                float c1, float o2, float h2,
+                                                float l2, float c2, float o3,
+                                                float h3, float l3, float c3) {
+  return c1 > o1 && c2 < o2 && o2 >= o1 && c2 <= c1 && o2 <= c1 && c2 >= o1 &&
+         c3 > o3 && c3 > c1;
 }
 
-__host__ __device__ inline bool is_three_line_strike(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3,
-    float o4, float h4, float l4, float c4) {
-    bool firstThree = c1 > o1 && c2 > o2 && c3 > o3 &&
-                      o2 >= o1 && o2 <= c1 &&
-                      o3 >= o2 && o3 <= c2 &&
-                      c1 < c2 && c2 < c3;
-    bool fourth = c4 < o4 && o4 >= c3 && c4 < o1;
-    return firstThree && fourth;
+__host__ __device__ inline bool
+is_three_line_strike(float o1, float h1, float l1, float c1, float o2, float h2,
+                     float l2, float c2, float o3, float h3, float l3, float c3,
+                     float o4, float h4, float l4, float c4) {
+  bool firstThree = c1 > o1 && c2 > o2 && c3 > o3 && o2 >= o1 && o2 <= c1 &&
+                    o3 >= o2 && o3 <= c2 && c1 < c2 && c2 < c3;
+  bool fourth = c4 < o4 && o4 >= c3 && c4 < o1;
+  return firstThree && fourth;
 }
 
-__host__ __device__ inline bool is_three_stars_in_south(
-    float o1, float h1, float l1, float c1,
-    float o2, float h2, float l2, float c2,
-    float o3, float h3, float l3, float c3) {
-    float ls1 = lower_shadow(l1, o1, c1);
-    float ls2 = lower_shadow(l2, o2, c2);
-    float ls3 = lower_shadow(l3, o3, c3);
-    return c1 < o1 && c2 < o2 && c3 < o3 &&
-           c1 > c2 && c2 > c3 &&
-           ls1 > ls2 && ls2 > ls3;
+__host__ __device__ inline bool
+is_three_stars_in_south(float o1, float h1, float l1, float c1, float o2,
+                        float h2, float l2, float c2, float o3, float h3,
+                        float l3, float c3) {
+  float ls1 = lower_shadow(l1, o1, c1);
+  float ls2 = lower_shadow(l2, o2, c2);
+  float ls3 = lower_shadow(l3, o3, c3);
+  return c1 < o1 && c2 < o2 && c3 < o3 && c1 > c2 && c2 > c3 && ls1 > ls2 &&
+         ls2 > ls3;
+}
+
+__host__ __device__ inline bool is_closing_marubozu(float open, float high,
+                                                    float low, float close) {
+  return (close == high && open > low) || (close == low && open < high);
+}
+
+__host__ __device__ inline bool
+is_conceal_baby_swallow(float o1, float h1, float l1, float c1, float o2,
+                        float h2, float l2, float c2, float o3, float h3,
+                        float l3, float c3, float o4, float h4, float l4,
+                        float c4) {
+  return c1 < o1 && c2 < o2 && c3 < o3 && c4 < o4 && c1 > c2 && c2 > c3 &&
+         c3 > c4;
+}
+
+__host__ __device__ inline bool is_counterattack(float o1, float h1, float l1,
+                                                 float c1, float o2, float h2,
+                                                 float l2, float c2) {
+  bool bullBear = c1 > o1 && c2 < o2;
+  bool bearBull = c1 < o1 && c2 > o2;
+  return (bullBear || bearBull) && fabsf(c2 - c1) <= 1e-3f;
+}
+
+__host__ __device__ inline bool is_dark_cloud_cover(float o1, float h1,
+                                                    float l1, float c1,
+                                                    float o2, float h2,
+                                                    float l2, float c2) {
+  float mid1 = (o1 + c1) * 0.5f;
+  return c1 > o1 && o2 > h1 && c2 < o2 && c2 > o1 && c2 < mid1;
 }
 
 #endif

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -11,46 +11,42 @@
 #include <indicators/ADXR.h>
 #include <indicators/APO.h>
 #include <indicators/ATR.h>
+#include <indicators/AbandonedBaby.h>
+#include <indicators/AdvanceBlock.h>
 #include <indicators/Aroon.h>
 #include <indicators/AroonOscillator.h>
 #include <indicators/AvgPrice.h>
-#include <indicators/TypPrice.h>
 #include <indicators/BBANDS.h>
 #include <indicators/BOP.h>
 #include <indicators/BearishEngulfing.h>
-#include <indicators/BullishEngulfing.h>
-#include <indicators/Beta.h>
-#include <indicators/Doji.h>
-#include <indicators/Hammer.h>
-#include <indicators/InvertedHammer.h>
-#include <indicators/ThreeWhiteSoldiers.h>
-#include <indicators/AbandonedBaby.h>
-#include <indicators/AdvanceBlock.h>
 #include <indicators/BeltHold.h>
+#include <indicators/Beta.h>
 #include <indicators/Breakaway.h>
-#include <indicators/TwoCrows.h>
-#include <indicators/ThreeBlackCrows.h>
-#include <indicators/ThreeInside.h>
-#include <indicators/ThreeLineStrike.h>
-#include <indicators/ThreeStarsInSouth.h>
+#include <indicators/BullishEngulfing.h>
 #include <indicators/CCI.h>
 #include <indicators/CMO.h>
 #include <indicators/Change.h>
+#include <indicators/ClosingMarubozu.h>
+#include <indicators/ConcealBabySwallow.h>
 #include <indicators/Correl.h>
+#include <indicators/CounterAttack.h>
 #include <indicators/DEMA.h>
 #include <indicators/DX.h>
+#include <indicators/DarkCloudCover.h>
+#include <indicators/Doji.h>
 #include <indicators/EMA.h>
 #include <indicators/HT_DCPERIOD.h>
 #include <indicators/HT_DCPHASE.h>
 #include <indicators/HT_PHASOR.h>
 #include <indicators/HT_SINE.h>
 #include <indicators/HT_TRENDMODE.h>
+#include <indicators/Hammer.h>
+#include <indicators/InvertedHammer.h>
 #include <indicators/KAMA.h>
 #include <indicators/LINEARREG.h>
 #include <indicators/LINEARREG_ANGLE.h>
 #include <indicators/LINEARREG_INTERCEPT.h>
 #include <indicators/LINEARREG_SLOPE.h>
-#include <indicators/TSF.h>
 #include <indicators/MA.h>
 #include <indicators/MACD.h>
 #include <indicators/MACDEXT.h>
@@ -75,7 +71,6 @@
 #include <indicators/SMA.h>
 #include <indicators/SUM.h>
 #include <indicators/StdDev.h>
-#include <indicators/VAR.h>
 #include <indicators/StochRSI.h>
 #include <indicators/Stochastic.h>
 #include <indicators/StochasticFast.h>
@@ -84,7 +79,16 @@
 #include <indicators/TRANGE.h>
 #include <indicators/TRIMA.h>
 #include <indicators/TRIX.h>
+#include <indicators/TSF.h>
+#include <indicators/ThreeBlackCrows.h>
+#include <indicators/ThreeInside.h>
+#include <indicators/ThreeLineStrike.h>
+#include <indicators/ThreeStarsInSouth.h>
+#include <indicators/ThreeWhiteSoldiers.h>
+#include <indicators/TwoCrows.h>
+#include <indicators/TypPrice.h>
 #include <indicators/ULTOSC.h>
+#include <indicators/VAR.h>
 #include <indicators/WMA.h>
 #include <utils/CudaUtils.h>
 
@@ -141,8 +145,8 @@ static ctStatus_t run_ohlc_indicator(T &ind, const float *h_open,
                                      const float *h_high, const float *h_low,
                                      const float *h_close, float *h_out,
                                      int size) {
-  DeviceBuffer d_open{nullptr}, d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
-      d_out{nullptr};
+  DeviceBuffer d_open{nullptr}, d_high{nullptr}, d_low{nullptr},
+      d_close{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
   cudaError_t err = cudaMalloc(&tmp, size * sizeof(float));
@@ -1621,10 +1625,10 @@ ctStatus_t ct_medprice(const float *host_high, const float *host_low,
 }
 
 ctStatus_t ct_typprice(const float *host_high, const float *host_low,
-                       const float *host_close, float *host_output,
-                       int size) {
+                       const float *host_close, float *host_output, int size) {
   TypPrice tp;
-  DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr}, d_out{nullptr};
+  DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
+      d_out{nullptr};
   float *tmp = nullptr;
 
   cudaError_t err = cudaMalloc(&tmp, size * sizeof(float));
@@ -2017,9 +2021,10 @@ ctStatus_t ct_cdl_hammer(const float *host_open, const float *host_high,
                             host_output, size);
 }
 
-ctStatus_t ct_cdl_inverted_hammer(const float *host_open, const float *host_high,
-                                  const float *host_low, const float *host_close,
-                                  float *host_output, int size) {
+ctStatus_t ct_cdl_inverted_hammer(const float *host_open,
+                                  const float *host_high, const float *host_low,
+                                  const float *host_close, float *host_output,
+                                  int size) {
   InvertedHammer ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
@@ -2028,8 +2033,8 @@ ctStatus_t ct_cdl_inverted_hammer(const float *host_open, const float *host_high
 ctStatus_t ct_cdl_bullish_engulfing(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
-                                    const float *host_close,
-                                    float *host_output, int size) {
+                                    const float *host_close, float *host_output,
+                                    int size) {
   BullishEngulfing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
@@ -2038,8 +2043,8 @@ ctStatus_t ct_cdl_bullish_engulfing(const float *host_open,
 ctStatus_t ct_cdl_bearish_engulfing(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
-                                    const float *host_close,
-                                    float *host_output, int size) {
+                                    const float *host_close, float *host_output,
+                                    int size) {
   BearishEngulfing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
@@ -2055,50 +2060,40 @@ ctStatus_t ct_cdl_three_white_soldiers(const float *host_open,
                             host_output, size);
 }
 
-ctStatus_t ct_cdl_abandoned_baby(const float *host_open,
-                                 const float *host_high,
-                                 const float *host_low,
-                                 const float *host_close,
+ctStatus_t ct_cdl_abandoned_baby(const float *host_open, const float *host_high,
+                                 const float *host_low, const float *host_close,
                                  float *host_output, int size) {
   AbandonedBaby ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
 
-ctStatus_t ct_cdl_advance_block(const float *host_open,
-                                const float *host_high,
-                                const float *host_low,
-                                const float *host_close,
+ctStatus_t ct_cdl_advance_block(const float *host_open, const float *host_high,
+                                const float *host_low, const float *host_close,
                                 float *host_output, int size) {
   AdvanceBlock ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
 
-ctStatus_t ct_cdl_belt_hold(const float *host_open,
-                            const float *host_high,
-                            const float *host_low,
-                            const float *host_close,
+ctStatus_t ct_cdl_belt_hold(const float *host_open, const float *host_high,
+                            const float *host_low, const float *host_close,
                             float *host_output, int size) {
   BeltHold ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
 
-ctStatus_t ct_cdl_breakaway(const float *host_open,
-                            const float *host_high,
-                            const float *host_low,
-                            const float *host_close,
+ctStatus_t ct_cdl_breakaway(const float *host_open, const float *host_high,
+                            const float *host_low, const float *host_close,
                             float *host_output, int size) {
   Breakaway ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
 
-ctStatus_t ct_cdl_two_crows(const float *host_open,
-                            const float *host_high,
-                            const float *host_low,
-                            const float *host_close,
+ctStatus_t ct_cdl_two_crows(const float *host_open, const float *host_high,
+                            const float *host_low, const float *host_close,
                             float *host_output, int size) {
   TwoCrows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
@@ -2108,17 +2103,15 @@ ctStatus_t ct_cdl_two_crows(const float *host_open,
 ctStatus_t ct_cdl_three_black_crows(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
-                                    const float *host_close,
-                                    float *host_output, int size) {
+                                    const float *host_close, float *host_output,
+                                    int size) {
   ThreeBlackCrows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
 
-ctStatus_t ct_cdl_three_inside(const float *host_open,
-                               const float *host_high,
-                               const float *host_low,
-                               const float *host_close,
+ctStatus_t ct_cdl_three_inside(const float *host_open, const float *host_high,
+                               const float *host_low, const float *host_close,
                                float *host_output, int size) {
   ThreeInside ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
@@ -2128,8 +2121,8 @@ ctStatus_t ct_cdl_three_inside(const float *host_open,
 ctStatus_t ct_cdl_three_line_strike(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
-                                    const float *host_close,
-                                    float *host_output, int size) {
+                                    const float *host_close, float *host_output,
+                                    int size) {
   ThreeLineStrike ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
@@ -2141,6 +2134,44 @@ ctStatus_t ct_cdl_three_stars_in_south(const float *host_open,
                                        const float *host_close,
                                        float *host_output, int size) {
   ThreeStarsInSouth ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_closing_marubozu(const float *host_open,
+                                   const float *host_high,
+                                   const float *host_low,
+                                   const float *host_close, float *host_output,
+                                   int size) {
+  ClosingMarubozu ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_conceal_baby_swallow(const float *host_open,
+                                       const float *host_high,
+                                       const float *host_low,
+                                       const float *host_close,
+                                       float *host_output, int size) {
+  ConcealBabySwallow ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_counterattack(const float *host_open, const float *host_high,
+                                const float *host_low, const float *host_close,
+                                float *host_output, int size) {
+  CounterAttack ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_dark_cloud_cover(const float *host_open,
+                                   const float *host_high,
+                                   const float *host_low,
+                                   const float *host_close, float *host_output,
+                                   int size) {
+  DarkCloudCover ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }

--- a/src/indicators/ClosingMarubozu.cu
+++ b/src/indicators/ClosingMarubozu.cu
@@ -1,0 +1,36 @@
+#include <indicators/ClosingMarubozu.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void closingMarubozuKernel(const float *__restrict__ open,
+                                      const float *__restrict__ high,
+                                      const float *__restrict__ low,
+                                      const float *__restrict__ close,
+                                      float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < size) {
+    output[idx] =
+        is_closing_marubozu(open[idx], high[idx], low[idx], close[idx]) ? 1.0f
+                                                                        : 0.0f;
+  }
+}
+
+void ClosingMarubozu::calculate(const float *open, const float *high,
+                                const float *low, const float *close,
+                                float *output, int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  closingMarubozuKernel<<<grid, block>>>(open, high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void ClosingMarubozu::calculate(const float *input, float *output,
+                                int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/ConcealBabySwallow.cu
+++ b/src/indicators/ConcealBabySwallow.cu
@@ -1,0 +1,42 @@
+#include <indicators/ConcealBabySwallow.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void concealBabySwallowKernel(const float *__restrict__ open,
+                                         const float *__restrict__ high,
+                                         const float *__restrict__ low,
+                                         const float *__restrict__ close,
+                                         float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx > 2 && idx < size) {
+    output[idx] =
+        is_conceal_baby_swallow(open[idx - 3], high[idx - 3], low[idx - 3],
+                                close[idx - 3], open[idx - 2], high[idx - 2],
+                                low[idx - 2], close[idx - 2], open[idx - 1],
+                                high[idx - 1], low[idx - 1], close[idx - 1],
+                                open[idx], high[idx], low[idx], close[idx])
+            ? 1.0f
+            : 0.0f;
+  }
+}
+
+void ConcealBabySwallow::calculate(const float *open, const float *high,
+                                   const float *low, const float *close,
+                                   float *output, int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  concealBabySwallowKernel<<<grid, block>>>(open, high, low, close, output,
+                                            size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void ConcealBabySwallow::calculate(const float *input, float *output,
+                                   int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/CounterAttack.cu
+++ b/src/indicators/CounterAttack.cu
@@ -1,0 +1,38 @@
+#include <indicators/CounterAttack.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void counterAttackKernel(const float *__restrict__ open,
+                                    const float *__restrict__ high,
+                                    const float *__restrict__ low,
+                                    const float *__restrict__ close,
+                                    float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx > 0 && idx < size) {
+    output[idx] = is_counterattack(open[idx - 1], high[idx - 1], low[idx - 1],
+                                   close[idx - 1], open[idx], high[idx],
+                                   low[idx], close[idx])
+                      ? 1.0f
+                      : 0.0f;
+  }
+}
+
+void CounterAttack::calculate(const float *open, const float *high,
+                              const float *low, const float *close,
+                              float *output, int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  counterAttackKernel<<<grid, block>>>(open, high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void CounterAttack::calculate(const float *input, float *output,
+                              int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/DarkCloudCover.cu
+++ b/src/indicators/DarkCloudCover.cu
@@ -1,0 +1,38 @@
+#include <indicators/DarkCloudCover.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void darkCloudCoverKernel(const float *__restrict__ open,
+                                     const float *__restrict__ high,
+                                     const float *__restrict__ low,
+                                     const float *__restrict__ close,
+                                     float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx > 0 && idx < size) {
+    output[idx] = is_dark_cloud_cover(open[idx - 1], high[idx - 1],
+                                      low[idx - 1], close[idx - 1], open[idx],
+                                      high[idx], low[idx], close[idx])
+                      ? 1.0f
+                      : 0.0f;
+  }
+}
+
+void DarkCloudCover::calculate(const float *open, const float *high,
+                               const float *low, const float *close,
+                               float *output, int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  darkCloudCoverKernel<<<grid, block>>>(open, high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void DarkCloudCover::calculate(const float *input, float *output,
+                               int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/tests/cpp/test_cdl_closing_marubozu.cpp
+++ b/tests/cpp/test_cdl_closing_marubozu.cpp
@@ -1,0 +1,17 @@
+#include "test_utils.hpp"
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLClosingMarubozu) {
+  const int N = 5;
+  std::vector<float> open{1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+  std::vector<float> high{1.5f, 2.5f, 3.5f, 4.5f, 5.5f};
+  std::vector<float> low{0.5f, 1.5f, 2.5f, 3.5f, 4.5f};
+  std::vector<float> close{1.2f, 2.3f, 3.5f, 3.8f, 4.8f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_closing_marubozu(open.data(), high.data(), low.data(),
+                                          close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_closing_marubozu failed";
+  expect_approx_equal(out, ref);
+}

--- a/tests/cpp/test_cdl_conceal_baby_swallow.cpp
+++ b/tests/cpp/test_cdl_conceal_baby_swallow.cpp
@@ -1,0 +1,24 @@
+#include "test_utils.hpp"
+#include <limits>
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLConcealBabySwallow) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 9.0f, 8.0f, 7.0f, 6.0f};
+  std::vector<float> high{10.2f, 9.2f, 8.2f, 7.2f, 6.2f};
+  std::vector<float> low{9.5f, 8.5f, 7.5f, 6.5f, 5.5f};
+  std::vector<float> close{9.7f, 8.7f, 7.7f, 6.7f, 6.3f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = std::numeric_limits<float>::quiet_NaN();
+  ref[3] = 1.0f;
+  ctStatus_t rc = ct_cdl_conceal_baby_swallow(
+      open.data(), high.data(), low.data(), close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_conceal_baby_swallow failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+  EXPECT_TRUE(std::isnan(out[2]));
+}

--- a/tests/cpp/test_cdl_counterattack.cpp
+++ b/tests/cpp/test_cdl_counterattack.cpp
@@ -1,0 +1,20 @@
+#include "test_utils.hpp"
+#include <limits>
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLCounterAttack) {
+  const int N = 3;
+  std::vector<float> open{1.0f, 2.5f, 3.0f};
+  std::vector<float> high{1.5f, 2.6f, 3.5f};
+  std::vector<float> low{0.5f, 1.0f, 2.5f};
+  std::vector<float> close{1.4f, 1.4f, 3.2f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = 1.0f;
+  ctStatus_t rc = ct_cdl_counterattack(open.data(), high.data(), low.data(),
+                                       close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_counterattack failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+}

--- a/tests/cpp/test_cdl_dark_cloud_cover.cpp
+++ b/tests/cpp/test_cdl_dark_cloud_cover.cpp
@@ -1,0 +1,20 @@
+#include "test_utils.hpp"
+#include <limits>
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLDarkCloudCover) {
+  const int N = 3;
+  std::vector<float> open{1.0f, 2.5f, 3.0f};
+  std::vector<float> high{1.5f, 3.0f, 3.5f};
+  std::vector<float> low{0.5f, 1.0f, 2.5f};
+  std::vector<float> close{1.4f, 1.1f, 3.2f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = 1.0f;
+  ctStatus_t rc = ct_cdl_dark_cloud_cover(open.data(), high.data(), low.data(),
+                                          close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_dark_cloud_cover failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+}


### PR DESCRIPTION
## Summary
- implement Closing Marubozu, Conceal Baby Swallow, Counterattack, and Dark Cloud Cover candlestick indicators
- expose new patterns via C API and Python bindings
- add unit tests for the new indicators

## Testing
- ❌ `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` (missing CUDA toolkit: Failed to find nvcc)

------
https://chatgpt.com/codex/tasks/task_e_68a8deb5bb1c8329bb8977701317560c