### PR TITLE
Add additional candlestick pattern indicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ set(INDICATOR_SOURCES
     src/indicators/ConcealBabySwallow.cu
     src/indicators/CounterAttack.cu
     src/indicators/DarkCloudCover.cu
+    src/indicators/DojiStar.cu
+    src/indicators/DragonflyDoji.cu
+    src/indicators/Engulfing.cu
+    src/indicators/EveningDojiStar.cu
+    src/indicators/EveningStar.cu
 )
 
 add_library(tacuda SHARED

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -195,6 +195,26 @@ _lib.ct_cdl_dark_cloud_cover.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.
                                          ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
                                          ctypes.POINTER(ctypes.c_float), ctypes.c_int]
 _lib.ct_cdl_dark_cloud_cover.restype  = ctypes.c_int
+_lib.ct_cdl_doji_star.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_doji_star.restype  = ctypes.c_int
+_lib.ct_cdl_dragonfly_doji.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                       ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                       ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_dragonfly_doji.restype  = ctypes.c_int
+_lib.ct_cdl_engulfing.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                  ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_engulfing.restype  = ctypes.c_int
+_lib.ct_cdl_evening_doji_star.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                          ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_evening_doji_star.restype  = ctypes.c_int
+_lib.ct_cdl_evening_star.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                     ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+                                     ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+_lib.ct_cdl_evening_star.restype  = ctypes.c_int
 
 def _as_float_ptr(arr):
     import numpy as np
@@ -679,6 +699,101 @@ def cdl_three_stars_in_south(open, high, low, close):
         raise RuntimeError("ct_cdl_three_stars_in_south failed")
     return out
 
+def cdl_doji_star(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_doji_star(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_doji_star failed")
+    return out
+
+def cdl_dragonfly_doji(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_dragonfly_doji(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_dragonfly_doji failed")
+    return out
+
+def cdl_engulfing(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_engulfing(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_engulfing failed")
+    return out
+
+def cdl_evening_doji_star(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_evening_doji_star(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_evening_doji_star failed")
+    return out
+
+def cdl_evening_star(open, high, low, close):
+    import numpy as np
+    open = np.asarray(open, dtype=np.float32)
+    high = np.asarray(high, dtype=np.float32)
+    low = np.asarray(low, dtype=np.float32)
+    close = np.asarray(close, dtype=np.float32)
+    if open.shape != high.shape or open.shape != low.shape or open.shape != close.shape:
+        raise ValueError("open, high, low, close must have same shape")
+    out = np.zeros_like(open)
+    _, po = _as_float_ptr(open)
+    _, ph = _as_float_ptr(high)
+    _, pl = _as_float_ptr(low)
+    _, pc = _as_float_ptr(close)
+    _, pout = _as_float_ptr(out)
+    rc = _lib.ct_cdl_evening_star(po, ph, pl, pc, pout, open.size)
+    if rc != 0:
+        raise RuntimeError("ct_cdl_evening_star failed")
+    return out
+
 def trange(high, low, close):
     import numpy as np
     high = np.asarray(high, dtype=np.float32)
@@ -772,6 +887,11 @@ __all__ = [
     "cdl_three_inside",
     "cdl_three_line_strike",
     "cdl_three_stars_in_south",
+    "cdl_doji_star",
+    "cdl_dragonfly_doji",
+    "cdl_engulfing",
+    "cdl_evening_doji_star",
+    "cdl_evening_star",
     "trange",
     "summation",
     "t3",

--- a/include/indicators/DojiStar.h
+++ b/include/indicators/DojiStar.h
@@ -1,0 +1,15 @@
+#ifndef DOJISTAR_H
+#define DOJISTAR_H
+
+#include "Indicator.h"
+
+class DojiStar : public Indicator {
+public:
+  DojiStar() = default;
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/DragonflyDoji.h
+++ b/include/indicators/DragonflyDoji.h
@@ -1,0 +1,15 @@
+#ifndef DRAGONFLYDOJI_H
+#define DRAGONFLYDOJI_H
+
+#include "Indicator.h"
+
+class DragonflyDoji : public Indicator {
+public:
+  DragonflyDoji() = default;
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/Engulfing.h
+++ b/include/indicators/Engulfing.h
@@ -1,0 +1,15 @@
+#ifndef ENGULFING_H
+#define ENGULFING_H
+
+#include "Indicator.h"
+
+class Engulfing : public Indicator {
+public:
+  Engulfing() = default;
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/EveningDojiStar.h
+++ b/include/indicators/EveningDojiStar.h
@@ -1,0 +1,15 @@
+#ifndef EVENINGDOJISTAR_H
+#define EVENINGDOJISTAR_H
+
+#include "Indicator.h"
+
+class EveningDojiStar : public Indicator {
+public:
+  EveningDojiStar() = default;
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/indicators/EveningStar.h
+++ b/include/indicators/EveningStar.h
@@ -1,0 +1,15 @@
+#ifndef EVENINGSTAR_H
+#define EVENINGSTAR_H
+
+#include "Indicator.h"
+
+class EveningStar : public Indicator {
+public:
+  EveningStar() = default;
+  void calculate(const float *open, const float *high, const float *low,
+                 const float *close, float *output, int size) noexcept(false);
+  void calculate(const float *input, float *output,
+                 int size) noexcept(false) override;
+};
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -271,6 +271,31 @@ CTAPI_EXPORT ctStatus_t ct_cdl_dark_cloud_cover(const float *host_open,
                                                 const float *host_low,
                                                 const float *host_close,
                                                 float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_doji_star(const float *host_open,
+                                         const float *host_high,
+                                         const float *host_low,
+                                         const float *host_close,
+                                         float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_dragonfly_doji(const float *host_open,
+                                              const float *host_high,
+                                              const float *host_low,
+                                              const float *host_close,
+                                              float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_engulfing(const float *host_open,
+                                         const float *host_high,
+                                         const float *host_low,
+                                         const float *host_close,
+                                         float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_evening_doji_star(const float *host_open,
+                                                 const float *host_high,
+                                                 const float *host_low,
+                                                 const float *host_close,
+                                                 float *host_output, int size);
+CTAPI_EXPORT ctStatus_t ct_cdl_evening_star(const float *host_open,
+                                            const float *host_high,
+                                            const float *host_low,
+                                            const float *host_close,
+                                            float *host_output, int size);
 CTAPI_EXPORT ctStatus_t ct_cmo(const float *host_input, float *host_output,
                                int size, int period);
 CTAPI_EXPORT ctStatus_t ct_correl(const float *host_x, const float *host_y,

--- a/include/utils/CandleUtils.h
+++ b/include/utils/CandleUtils.h
@@ -184,4 +184,58 @@ __host__ __device__ inline bool is_dark_cloud_cover(float o1, float h1,
   return c1 > o1 && o2 > h1 && c2 < o2 && c2 > o1 && c2 < mid1;
 }
 
+__host__ __device__ inline bool is_doji_star(float o1, float h1, float l1,
+                                             float c1, float o2, float h2,
+                                             float l2, float c2) {
+  bool gapUp = l2 > h1;
+  bool gapDown = h2 < l1;
+  return !is_doji(o1, h1, l1, c1) && is_doji(o2, h2, l2, c2) &&
+         (gapUp || gapDown);
+}
+
+__host__ __device__ inline bool is_dragonfly_doji(float open, float high,
+                                                  float low, float close) {
+  if (!is_doji(open, high, low, close))
+    return false;
+  float range = high - low;
+  float upper = upper_shadow(high, open, close);
+  float lower = lower_shadow(low, open, close);
+  return upper <= range * 0.1f && lower >= range * 0.5f;
+}
+
+__host__ __device__ inline float engulfing(float prevOpen, float prevClose,
+                                           float open, float close) {
+  if (is_bullish_engulfing(prevOpen, prevClose, open, close))
+    return 1.0f;
+  if (is_bearish_engulfing(prevOpen, prevClose, open, close))
+    return -1.0f;
+  return 0.0f;
+}
+
+__host__ __device__ inline bool is_evening_star(float o1, float h1, float l1,
+                                                float c1, float o2, float h2,
+                                                float l2, float c2, float o3,
+                                                float h3, float l3, float c3) {
+  bool bullish1 = c1 > o1;
+  bool gapUp = l2 > h1;
+  float body1 = real_body(o1, c1);
+  float body2 = real_body(o2, c2);
+  bool smallBody2 = body2 < body1 * 0.5f;
+  bool bearish3 = c3 < o3;
+  bool closeIntoBody = c3 < (o1 + c1) * 0.5f;
+  return bullish1 && gapUp && smallBody2 && bearish3 && closeIntoBody;
+}
+
+__host__ __device__ inline bool
+is_evening_doji_star(float o1, float h1, float l1, float c1, float o2, float h2,
+                     float l2, float c2, float o3, float h3, float l3,
+                     float c3) {
+  bool bullish1 = c1 > o1;
+  bool doji2 = is_doji(o2, h2, l2, c2);
+  bool gapUp = l2 > h1;
+  bool bearish3 = c3 < o3;
+  bool closeIntoBody = c3 < (o1 + c1) * 0.5f;
+  return bullish1 && doji2 && gapUp && bearish3 && closeIntoBody;
+}
+
 #endif

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -34,7 +34,12 @@
 #include <indicators/DX.h>
 #include <indicators/DarkCloudCover.h>
 #include <indicators/Doji.h>
+#include <indicators/DojiStar.h>
+#include <indicators/DragonflyDoji.h>
 #include <indicators/EMA.h>
+#include <indicators/Engulfing.h>
+#include <indicators/EveningDojiStar.h>
+#include <indicators/EveningStar.h>
 #include <indicators/HT_DCPERIOD.h>
 #include <indicators/HT_DCPHASE.h>
 #include <indicators/HT_PHASOR.h>
@@ -2172,6 +2177,48 @@ ctStatus_t ct_cdl_dark_cloud_cover(const float *host_open,
                                    const float *host_close, float *host_output,
                                    int size) {
   DarkCloudCover ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_doji_star(const float *host_open, const float *host_high,
+                            const float *host_low, const float *host_close,
+                            float *host_output, int size) {
+  DojiStar ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_dragonfly_doji(const float *host_open, const float *host_high,
+                                 const float *host_low, const float *host_close,
+                                 float *host_output, int size) {
+  DragonflyDoji ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_engulfing(const float *host_open, const float *host_high,
+                            const float *host_low, const float *host_close,
+                            float *host_output, int size) {
+  Engulfing ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_evening_doji_star(const float *host_open,
+                                    const float *host_high,
+                                    const float *host_low,
+                                    const float *host_close, float *host_output,
+                                    int size) {
+  EveningDojiStar ind;
+  return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
+                            host_output, size);
+}
+
+ctStatus_t ct_cdl_evening_star(const float *host_open, const float *host_high,
+                               const float *host_low, const float *host_close,
+                               float *host_output, int size) {
+  EveningStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }

--- a/src/indicators/DojiStar.cu
+++ b/src/indicators/DojiStar.cu
@@ -1,0 +1,38 @@
+#include <indicators/DojiStar.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void dojiStarKernel(const float *__restrict__ open,
+                               const float *__restrict__ high,
+                               const float *__restrict__ low,
+                               const float *__restrict__ close,
+                               float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx > 0 && idx < size) {
+    output[idx] =
+        is_doji_star(open[idx - 1], high[idx - 1], low[idx - 1], close[idx - 1],
+                     open[idx], high[idx], low[idx], close[idx])
+            ? 1.0f
+            : 0.0f;
+  }
+}
+
+void DojiStar::calculate(const float *open, const float *high, const float *low,
+                         const float *close, float *output,
+                         int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  dojiStarKernel<<<grid, block>>>(open, high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void DojiStar::calculate(const float *input, float *output,
+                         int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/DragonflyDoji.cu
+++ b/src/indicators/DragonflyDoji.cu
@@ -1,0 +1,36 @@
+#include <indicators/DragonflyDoji.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void dragonflyDojiKernel(const float *__restrict__ open,
+                                    const float *__restrict__ high,
+                                    const float *__restrict__ low,
+                                    const float *__restrict__ close,
+                                    float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < size) {
+    output[idx] = is_dragonfly_doji(open[idx], high[idx], low[idx], close[idx])
+                      ? 1.0f
+                      : 0.0f;
+  }
+}
+
+void DragonflyDoji::calculate(const float *open, const float *high,
+                              const float *low, const float *close,
+                              float *output, int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  dragonflyDojiKernel<<<grid, block>>>(open, high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void DragonflyDoji::calculate(const float *input, float *output,
+                              int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/Engulfing.cu
+++ b/src/indicators/Engulfing.cu
@@ -1,0 +1,35 @@
+#include <indicators/Engulfing.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void engulfingKernel(const float *__restrict__ open,
+                                const float *__restrict__ high,
+                                const float *__restrict__ low,
+                                const float *__restrict__ close,
+                                float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx > 0 && idx < size) {
+    output[idx] =
+        engulfing(open[idx - 1], close[idx - 1], open[idx], close[idx]);
+  }
+}
+
+void Engulfing::calculate(const float *open, const float *high,
+                          const float *low, const float *close, float *output,
+                          int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  engulfingKernel<<<grid, block>>>(open, high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void Engulfing::calculate(const float *input, float *output,
+                          int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/EveningDojiStar.cu
+++ b/src/indicators/EveningDojiStar.cu
@@ -1,0 +1,40 @@
+#include <indicators/EveningDojiStar.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void eveningDojiStarKernel(const float *__restrict__ open,
+                                      const float *__restrict__ high,
+                                      const float *__restrict__ low,
+                                      const float *__restrict__ close,
+                                      float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx > 1 && idx < size) {
+    output[idx] =
+        is_evening_doji_star(open[idx - 2], high[idx - 2], low[idx - 2],
+                             close[idx - 2], open[idx - 1], high[idx - 1],
+                             low[idx - 1], close[idx - 1], open[idx], high[idx],
+                             low[idx], close[idx])
+            ? 1.0f
+            : 0.0f;
+  }
+}
+
+void EveningDojiStar::calculate(const float *open, const float *high,
+                                const float *low, const float *close,
+                                float *output, int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  eveningDojiStarKernel<<<grid, block>>>(open, high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void EveningDojiStar::calculate(const float *input, float *output,
+                                int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/src/indicators/EveningStar.cu
+++ b/src/indicators/EveningStar.cu
@@ -1,0 +1,39 @@
+#include <indicators/EveningStar.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+__global__ void eveningStarKernel(const float *__restrict__ open,
+                                  const float *__restrict__ high,
+                                  const float *__restrict__ low,
+                                  const float *__restrict__ close,
+                                  float *__restrict__ output, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx > 1 && idx < size) {
+    output[idx] = is_evening_star(open[idx - 2], high[idx - 2], low[idx - 2],
+                                  close[idx - 2], open[idx - 1], high[idx - 1],
+                                  low[idx - 1], close[idx - 1], open[idx],
+                                  high[idx], low[idx], close[idx])
+                      ? 1.0f
+                      : 0.0f;
+  }
+}
+
+void EveningStar::calculate(const float *open, const float *high,
+                            const float *low, const float *close, float *output,
+                            int size) noexcept(false) {
+  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  dim3 block = defaultBlock();
+  dim3 grid = defaultGrid(size);
+  eveningStarKernel<<<grid, block>>>(open, high, low, close, output, size);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void EveningStar::calculate(const float *input, float *output,
+                            int size) noexcept(false) {
+  const float *open = input;
+  const float *high = input + size;
+  const float *low = input + 2 * size;
+  const float *close = input + 3 * size;
+  calculate(open, high, low, close, output, size);
+}

--- a/tests/cpp/test_cdl_doji_star.cpp
+++ b/tests/cpp/test_cdl_doji_star.cpp
@@ -1,0 +1,20 @@
+#include "test_utils.hpp"
+#include <limits>
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLDojiStar) {
+  const int N = 4;
+  std::vector<float> open{1.0f, 1.0f, 1.6f, 1.5f};
+  std::vector<float> high{1.1f, 1.5f, 1.65f, 1.6f};
+  std::vector<float> low{0.9f, 0.95f, 1.55f, 1.45f};
+  std::vector<float> close{1.05f, 1.4f, 1.6f, 1.55f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_doji_star(open.data(), high.data(), low.data(),
+                                   close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_doji_star failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+}

--- a/tests/cpp/test_cdl_dragonfly_doji.cpp
+++ b/tests/cpp/test_cdl_dragonfly_doji.cpp
@@ -1,0 +1,17 @@
+#include "test_utils.hpp"
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLDragonflyDoji) {
+  const int N = 3;
+  std::vector<float> open{1.0f, 2.0f, 3.0f};
+  std::vector<float> high{1.1f, 2.0f, 3.2f};
+  std::vector<float> low{0.9f, 1.5f, 2.8f};
+  std::vector<float> close{1.05f, 2.0f, 3.1f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[1] = 1.0f;
+  ctStatus_t rc = ct_cdl_dragonfly_doji(open.data(), high.data(), low.data(),
+                                        close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_dragonfly_doji failed";
+  expect_approx_equal(out, ref);
+}

--- a/tests/cpp/test_cdl_engulfing.cpp
+++ b/tests/cpp/test_cdl_engulfing.cpp
@@ -1,0 +1,21 @@
+#include "test_utils.hpp"
+#include <limits>
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLEngulfing) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 9.5f, 9.1f, 10.5f, 10.9f};
+  std::vector<float> high{10.2f, 9.7f, 9.9f, 11.0f, 11.1f};
+  std::vector<float> low{9.7f, 9.1f, 9.0f, 10.4f, 10.0f};
+  std::vector<float> close{9.8f, 9.2f, 9.8f, 10.8f, 10.2f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ref[4] = -1.0f;
+  ctStatus_t rc = ct_cdl_engulfing(open.data(), high.data(), low.data(),
+                                   close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_engulfing failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+}

--- a/tests/cpp/test_cdl_evening_doji_star.cpp
+++ b/tests/cpp/test_cdl_evening_doji_star.cpp
@@ -1,0 +1,22 @@
+#include "test_utils.hpp"
+#include <limits>
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLEveningDojiStar) {
+  const int N = 5;
+  std::vector<float> open{1.0f, 1.7f, 1.7f, 1.5f, 1.5f};
+  std::vector<float> high{1.6f, 1.75f, 1.8f, 1.6f, 1.6f};
+  std::vector<float> low{0.9f, 1.65f, 1.1f, 1.4f, 1.4f};
+  std::vector<float> close{1.5f, 1.7f, 1.2f, 1.55f, 1.55f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_evening_doji_star(open.data(), high.data(), low.data(),
+                                           close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_evening_doji_star failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+}

--- a/tests/cpp/test_cdl_evening_star.cpp
+++ b/tests/cpp/test_cdl_evening_star.cpp
@@ -1,0 +1,22 @@
+#include "test_utils.hpp"
+#include <limits>
+#include <tacuda.h>
+#include <vector>
+
+TEST(Tacuda, CDLEveningStar) {
+  const int N = 5;
+  std::vector<float> open{1.0f, 1.7f, 1.7f, 1.5f, 1.5f};
+  std::vector<float> high{1.6f, 1.75f, 1.8f, 1.6f, 1.6f};
+  std::vector<float> low{0.9f, 1.65f, 1.1f, 1.4f, 1.4f};
+  std::vector<float> close{1.5f, 1.72f, 1.2f, 1.55f, 1.55f};
+  std::vector<float> out(N), ref(N, 0.0f);
+  ref[0] = std::numeric_limits<float>::quiet_NaN();
+  ref[1] = std::numeric_limits<float>::quiet_NaN();
+  ref[2] = 1.0f;
+  ctStatus_t rc = ct_cdl_evening_star(open.data(), high.data(), low.data(),
+                                      close.data(), out.data(), N);
+  ASSERT_EQ(rc, CT_STATUS_SUCCESS) << "ct_cdl_evening_star failed";
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+}


### PR DESCRIPTION
## Summary
- add Doji Star, Dragonfly Doji, Engulfing, Evening Doji Star and Evening Star candlestick pattern indicators
- expose new patterns through C API and Python bindings
- cover new indicators with CUDA kernels and unit tests

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation error)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e083ea288329b5e016bcdb55574d