### PR TITLE
Remove Python dependency for Hilbert indicators

### DIFF
--- a/src/indicators/HT_DCPERIOD.cu
+++ b/src/indicators/HT_DCPERIOD.cu
@@ -1,37 +1,219 @@
 #include <indicators/HT_DCPERIOD.h>
+// Implementation based on TA-Lib's HT_DCPERIOD algorithm, but executed
+// directly in C++ to avoid spawning a Python interpreter at runtime.
 #include <utils/CudaUtils.h>
 #include <cuda_runtime.h>
 #include <limits>
-#include <stdexcept>
+#include <cmath>
 #include <vector>
-#include <sstream>
-#include <cstdio>
 
-static void run_ht_dcperiod_python(const std::vector<float>& in, std::vector<float>& out) {
-    std::ostringstream cmd;
-    cmd << "python3 - <<'PY'\n";
-    cmd << "import numpy as np\n";
-    cmd << "try:\n import talib\nexcept Exception:\n import subprocess, sys\n subprocess.check_call([sys.executable,'-m','pip','install','-q','TA-Lib'])\n import talib\n";
-    cmd << "x=np.array([";
-    for (size_t i = 0; i < in.size(); ++i) { if (i) cmd << ','; cmd << in[i]; }
-    cmd << "],dtype=float)\n";
-    cmd << "res=talib.HT_DCPERIOD(x)\n";
-    cmd << "print('\\n'.join(str(v) for v in res))\n";
-    cmd << "PY";
-    FILE* pipe = popen(cmd.str().c_str(), "r");
-    if (!pipe) throw std::runtime_error("popen failed");
-    char buf[256];
-    size_t idx = 0;
-    while (idx < out.size() && fgets(buf, sizeof(buf), pipe)) {
-        out[idx++] = std::strtof(buf, nullptr);
+static void ht_dcperiod_cpu(const std::vector<float>& in, std::vector<float>& out) {
+    const int size = static_cast<int>(in.size());
+    const int lookbackTotal = 32;  // as defined by TA-Lib
+    if (size <= lookbackTotal)
+        return;  // output remains NaN
+
+    const double a = 0.0962;
+    const double b = 0.5769;
+    const double rad2Deg = 180.0 / (4.0 * std::atan(1.0));
+
+    double period = 0.0, smoothPeriod = 0.0;
+    double periodWMASub, periodWMASum, trailingWMAValue, smoothedValue;
+    double hilbertTempReal;
+    int trailingWMAIdx, hilbertIdx;
+    double Q2 = 0.0, I2 = 0.0, prevQ2 = 0.0, prevI2 = 0.0, Re = 0.0, Im = 0.0;
+    double I1ForOddPrev2 = 0.0, I1ForOddPrev3 = 0.0;
+    double I1ForEvenPrev2 = 0.0, I1ForEvenPrev3 = 0.0;
+
+    // Hilbert transform state
+    double detrender_Odd[3] = {0.0}, detrender_Even[3] = {0.0};
+    double prev_detrender_Odd = 0.0, prev_detrender_Even = 0.0;
+    double prev_detrender_input_Odd = 0.0, prev_detrender_input_Even = 0.0;
+    double detrender = 0.0;
+
+    double Q1_Odd[3] = {0.0}, Q1_Even[3] = {0.0};
+    double prev_Q1_Odd = 0.0, prev_Q1_Even = 0.0;
+    double prev_Q1_input_Odd = 0.0, prev_Q1_input_Even = 0.0;
+    double Q1 = 0.0;
+
+    double jI_Odd[3] = {0.0}, jI_Even[3] = {0.0};
+    double prev_jI_Odd = 0.0, prev_jI_Even = 0.0;
+    double prev_jI_input_Odd = 0.0, prev_jI_input_Even = 0.0;
+    double jI = 0.0;
+
+    double jQ_Odd[3] = {0.0}, jQ_Even[3] = {0.0};
+    double prev_jQ_Odd = 0.0, prev_jQ_Even = 0.0;
+    double prev_jQ_input_Odd = 0.0, prev_jQ_input_Even = 0.0;
+    double jQ = 0.0;
+
+    int startIdx = lookbackTotal;
+    int endIdx = size - 1;
+    trailingWMAIdx = startIdx - lookbackTotal;
+    int today = trailingWMAIdx;
+
+    double tempReal = in[today++];
+    periodWMASub = tempReal;
+    periodWMASum = tempReal;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 2.0;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 3.0;
+    trailingWMAValue = 0.0;
+
+    auto doPriceWMA = [&](double newPrice, double& smoothed) {
+        periodWMASub += newPrice;
+        periodWMASub -= trailingWMAValue;
+        periodWMASum += newPrice * 4.0;
+        trailingWMAValue = in[trailingWMAIdx++];
+        smoothed = periodWMASum * 0.1;
+        periodWMASum -= periodWMASub;
+    };
+
+    for (int i = 0; i < 9; ++i) {
+        tempReal = in[today++];
+        doPriceWMA(tempReal, smoothedValue);
     }
-    pclose(pipe);
+
+    hilbertIdx = 0;
+
+    while (today <= endIdx) {
+        double adjustedPrevPeriod = (0.075 * period) + 0.54;
+        double todayValue = in[today];
+        doPriceWMA(todayValue, smoothedValue);
+
+        if ((today % 2) == 0) {
+            // Even
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Even[hilbertIdx];
+            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Even;
+            prev_detrender_Even = b * prev_detrender_input_Even;
+            detrender += prev_detrender_Even;
+            prev_detrender_input_Even = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Even[hilbertIdx];
+            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Even;
+            prev_Q1_Even = b * prev_Q1_input_Even;
+            Q1 += prev_Q1_Even;
+            prev_Q1_input_Even = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForEvenPrev3;
+            jI = -jI_Even[hilbertIdx];
+            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Even;
+            prev_jI_Even = b * prev_jI_input_Even;
+            jI += prev_jI_Even;
+            prev_jI_input_Even = I1ForEvenPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Even[hilbertIdx];
+            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Even;
+            prev_jQ_Even = b * prev_jQ_input_Even;
+            jQ += prev_jQ_Even;
+            prev_jQ_input_Even = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForEvenPrev3 - jQ)) + (0.8 * prevI2);
+
+            I1ForOddPrev3 = I1ForOddPrev2;
+            I1ForOddPrev2 = detrender;
+        } else {
+            // Odd
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Odd[hilbertIdx];
+            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Odd;
+            prev_detrender_Odd = b * prev_detrender_input_Odd;
+            detrender += prev_detrender_Odd;
+            prev_detrender_input_Odd = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Odd[hilbertIdx];
+            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Odd;
+            prev_Q1_Odd = b * prev_Q1_input_Odd;
+            Q1 += prev_Q1_Odd;
+            prev_Q1_input_Odd = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForOddPrev3;
+            jI = -jI_Odd[hilbertIdx];
+            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Odd;
+            prev_jI_Odd = b * prev_jI_input_Odd;
+            jI += prev_jI_Odd;
+            prev_jI_input_Odd = I1ForOddPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Odd[hilbertIdx];
+            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Odd;
+            prev_jQ_Odd = b * prev_jQ_input_Odd;
+            jQ += prev_jQ_Odd;
+            prev_jQ_input_Odd = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForOddPrev3 - jQ)) + (0.8 * prevI2);
+
+            I1ForEvenPrev3 = I1ForEvenPrev2;
+            I1ForEvenPrev2 = detrender;
+        }
+
+        Re = (0.2 * ((I2 * prevI2) + (Q2 * prevQ2))) + (0.8 * Re);
+        Im = (0.2 * ((I2 * prevQ2) - (Q2 * prevI2))) + (0.8 * Im);
+        prevQ2 = Q2;
+        prevI2 = I2;
+        tempReal = period;
+        if ((Im != 0.0) && (Re != 0.0))
+            period = 360.0 / (std::atan(Im / Re) * rad2Deg);
+        double tempReal2 = 1.5 * tempReal;
+        if (period > tempReal2)
+            period = tempReal2;
+        tempReal2 = 0.67 * tempReal;
+        if (period < tempReal2)
+            period = tempReal2;
+        if (period < 6)
+            period = 6;
+        else if (period > 50)
+            period = 50;
+        period = (0.2 * period) + (0.8 * tempReal);
+        smoothPeriod = (0.33 * period) + (0.67 * smoothPeriod);
+
+        if (today >= startIdx)
+            out[today] = static_cast<float>(smoothPeriod);
+
+        today++;
+    }
 }
 
 void HT_DCPERIOD::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
-    std::vector<float> h_in(size), h_out(size, std::numeric_limits<float>::quiet_NaN());
-    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size*sizeof(float), cudaMemcpyDeviceToHost));
-    run_ht_dcperiod_python(h_in, h_out);
-    CUDA_CHECK(cudaMemcpy(output, h_out.data(), size*sizeof(float), cudaMemcpyHostToDevice));
+    std::vector<float> h_in(size);
+    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
+    std::vector<float> h_out(size, std::numeric_limits<float>::quiet_NaN());
+    ht_dcperiod_cpu(h_in, h_out);
+    CUDA_CHECK(cudaMemcpy(output, h_out.data(), size * sizeof(float), cudaMemcpyHostToDevice));
 }
 

--- a/src/indicators/HT_DCPHASE.cu
+++ b/src/indicators/HT_DCPHASE.cu
@@ -2,36 +2,258 @@
 #include <utils/CudaUtils.h>
 #include <cuda_runtime.h>
 #include <limits>
-#include <stdexcept>
+#include <cmath>
 #include <vector>
-#include <sstream>
-#include <cstdio>
 
-static void run_ht_dcphase_python(const std::vector<float>& in, std::vector<float>& out) {
-    std::ostringstream cmd;
-    cmd << "python3 - <<'PY'\n";
-    cmd << "import numpy as np\n";
-    cmd << "try:\n import talib\nexcept Exception:\n import subprocess, sys\n subprocess.check_call([sys.executable,'-m','pip','install','-q','TA-Lib'])\n import talib\n";
-    cmd << "x=np.array([";
-    for (size_t i = 0; i < in.size(); ++i) { if (i) cmd << ','; cmd << in[i]; }
-    cmd << "],dtype=float)\n";
-    cmd << "res=talib.HT_DCPHASE(x)\n";
-    cmd << "print('\\n'.join(str(v) for v in res))\n";
-    cmd << "PY";
-    FILE* pipe = popen(cmd.str().c_str(), "r");
-    if (!pipe) throw std::runtime_error("popen failed");
-    char buf[256];
-    size_t idx = 0;
-    while (idx < out.size() && fgets(buf, sizeof(buf), pipe)) {
-        out[idx++] = std::strtof(buf, nullptr);
+// Port of TA-Lib's HT_DCPHASE implemented directly in C++.
+static void ht_dcphase_cpu(const std::vector<float>& in, std::vector<float>& out) {
+    const int size = static_cast<int>(in.size());
+    const int lookbackTotal = 63; // TA-Lib lookback
+    if (size <= lookbackTotal)
+        return;
+
+    const double a = 0.0962;
+    const double b = 0.5769;
+    const double tempPI = std::atan(1.0);
+    const double rad2Deg = 45.0 / tempPI;
+    const double constDeg2RadBy360 = tempPI * 8.0;
+
+    double period = 0.0, smoothPeriod = 0.0;
+    double periodWMASub, periodWMASum, trailingWMAValue, smoothedValue;
+    double hilbertTempReal;
+    int trailingWMAIdx, hilbertIdx;
+    double Q2 = 0.0, I2 = 0.0, prevQ2 = 0.0, prevI2 = 0.0, Re = 0.0, Im = 0.0;
+    double I1ForOddPrev2 = 0.0, I1ForOddPrev3 = 0.0;
+    double I1ForEvenPrev2 = 0.0, I1ForEvenPrev3 = 0.0;
+
+    double detrender_Odd[3] = {0.0}, detrender_Even[3] = {0.0};
+    double prev_detrender_Odd = 0.0, prev_detrender_Even = 0.0;
+    double prev_detrender_input_Odd = 0.0, prev_detrender_input_Even = 0.0;
+    double detrender = 0.0;
+
+    double Q1_Odd[3] = {0.0}, Q1_Even[3] = {0.0};
+    double prev_Q1_Odd = 0.0, prev_Q1_Even = 0.0;
+    double prev_Q1_input_Odd = 0.0, prev_Q1_input_Even = 0.0;
+    double Q1 = 0.0;
+
+    double jI_Odd[3] = {0.0}, jI_Even[3] = {0.0};
+    double prev_jI_Odd = 0.0, prev_jI_Even = 0.0;
+    double prev_jI_input_Odd = 0.0, prev_jI_input_Even = 0.0;
+    double jI = 0.0;
+
+    double jQ_Odd[3] = {0.0}, jQ_Even[3] = {0.0};
+    double prev_jQ_Odd = 0.0, prev_jQ_Even = 0.0;
+    double prev_jQ_input_Odd = 0.0, prev_jQ_input_Even = 0.0;
+    double jQ = 0.0;
+
+    std::vector<double> smoothPrice(50, 0.0);
+    int smoothPrice_Idx = 0;
+
+    int startIdx = lookbackTotal;
+    int endIdx = size - 1;
+    trailingWMAIdx = startIdx - lookbackTotal;
+    int today = trailingWMAIdx;
+
+    double tempReal = in[today++];
+    periodWMASub = tempReal;
+    periodWMASum = tempReal;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 2.0;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 3.0;
+    trailingWMAValue = 0.0;
+
+    auto doPriceWMA = [&](double newPrice, double& smoothed) {
+        periodWMASub += newPrice;
+        periodWMASub -= trailingWMAValue;
+        periodWMASum += newPrice * 4.0;
+        trailingWMAValue = in[trailingWMAIdx++];
+        smoothed = periodWMASum * 0.1;
+        periodWMASum -= periodWMASub;
+    };
+
+    for (int i = 0; i < 34; ++i) {
+        tempReal = in[today++];
+        doPriceWMA(tempReal, smoothedValue);
     }
-    pclose(pipe);
+
+    hilbertIdx = 0;
+
+    while (today <= endIdx) {
+        double adjustedPrevPeriod = (0.075 * period) + 0.54;
+        double todayValue = in[today];
+        doPriceWMA(todayValue, smoothedValue);
+        smoothPrice[smoothPrice_Idx] = smoothedValue;
+
+        if ((today & 1) == 0) {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Even[hilbertIdx];
+            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Even;
+            prev_detrender_Even = b * prev_detrender_input_Even;
+            detrender += prev_detrender_Even;
+            prev_detrender_input_Even = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Even[hilbertIdx];
+            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Even;
+            prev_Q1_Even = b * prev_Q1_input_Even;
+            Q1 += prev_Q1_Even;
+            prev_Q1_input_Even = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForEvenPrev3;
+            jI = -jI_Even[hilbertIdx];
+            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Even;
+            prev_jI_Even = b * prev_jI_input_Even;
+            jI += prev_jI_Even;
+            prev_jI_input_Even = I1ForEvenPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Even[hilbertIdx];
+            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Even;
+            prev_jQ_Even = b * prev_jQ_input_Even;
+            jQ += prev_jQ_Even;
+            prev_jQ_input_Even = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForEvenPrev3 - jQ)) + (0.8 * prevI2);
+
+            I1ForOddPrev3 = I1ForOddPrev2;
+            I1ForOddPrev2 = detrender;
+        } else {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Odd[hilbertIdx];
+            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Odd;
+            prev_detrender_Odd = b * prev_detrender_input_Odd;
+            detrender += prev_detrender_Odd;
+            prev_detrender_input_Odd = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Odd[hilbertIdx];
+            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Odd;
+            prev_Q1_Odd = b * prev_Q1_input_Odd;
+            Q1 += prev_Q1_Odd;
+            prev_Q1_input_Odd = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForOddPrev3;
+            jI = -jI_Odd[hilbertIdx];
+            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Odd;
+            prev_jI_Odd = b * prev_jI_input_Odd;
+            jI += prev_jI_Odd;
+            prev_jI_input_Odd = I1ForOddPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Odd[hilbertIdx];
+            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Odd;
+            prev_jQ_Odd = b * prev_jQ_input_Odd;
+            jQ += prev_jQ_Odd;
+            prev_jQ_input_Odd = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForOddPrev3 - jQ)) + (0.8 * prevI2);
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            I1ForEvenPrev3 = I1ForEvenPrev2;
+            I1ForEvenPrev2 = detrender;
+        }
+
+        Re = (0.2 * ((I2 * prevI2) + (Q2 * prevQ2))) + (0.8 * Re);
+        Im = (0.2 * ((I2 * prevQ2) - (Q2 * prevI2))) + (0.8 * Im);
+        prevQ2 = Q2;
+        prevI2 = I2;
+        double temp = period;
+        if ((Im != 0.0) && (Re != 0.0))
+            period = 360.0 / (std::atan(Im / Re) * rad2Deg);
+        double temp2 = 1.5 * temp;
+        if (period > temp2) period = temp2;
+        temp2 = 0.67 * temp;
+        if (period < temp2) period = temp2;
+        if (period < 6) period = 6;
+        else if (period > 50) period = 50;
+        period = (0.2 * period) + (0.8 * temp);
+        smoothPeriod = (0.33 * period) + (0.67 * smoothPeriod);
+
+        double DCPeriod = smoothPeriod + 0.5;
+        int DCPeriodInt = static_cast<int>(DCPeriod);
+        double realPart = 0.0, imagPart = 0.0;
+        int idx = smoothPrice_Idx;
+        for (int i = 0; i < DCPeriodInt; ++i) {
+            double phase = (i * constDeg2RadBy360) / DCPeriodInt;
+            double cosVal = std::cos(phase);
+            double sinVal = std::sin(phase);
+            double tempPrice = smoothPrice[idx];
+            realPart += sinVal * tempPrice;
+            imagPart += cosVal * tempPrice;
+            if (idx == 0)
+                idx = 49;
+            else
+                idx--;
+        }
+        double DCPhase;
+        double absImag = std::fabs(imagPart);
+        if (absImag > 0.0)
+            DCPhase = std::atan(realPart / imagPart) * rad2Deg;
+        else if (absImag <= 0.01) {
+            if (realPart < 0.0)
+                DCPhase = -90.0;
+            else if (realPart > 0.0)
+                DCPhase = 90.0;
+            else
+                DCPhase = 0.0;
+        } else {
+            DCPhase = 0.0;
+        }
+        DCPhase += 90.0;
+        DCPhase += 360.0 / smoothPeriod;
+        if (imagPart < 0.0)
+            DCPhase += 180.0;
+        if (DCPhase > 315.0)
+            DCPhase -= 360.0;
+
+        if (today >= startIdx)
+            out[today] = static_cast<float>(DCPhase);
+
+        if (++smoothPrice_Idx == 50)
+            smoothPrice_Idx = 0;
+        today++;
+    }
 }
 
 void HT_DCPHASE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
-    std::vector<float> h_in(size), h_out(size, std::numeric_limits<float>::quiet_NaN());
-    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size*sizeof(float), cudaMemcpyDeviceToHost));
-    run_ht_dcphase_python(h_in, h_out);
-    CUDA_CHECK(cudaMemcpy(output, h_out.data(), size*sizeof(float), cudaMemcpyHostToDevice));
+    std::vector<float> h_in(size);
+    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
+    std::vector<float> h_out(size, std::numeric_limits<float>::quiet_NaN());
+    ht_dcphase_cpu(h_in, h_out);
+    CUDA_CHECK(cudaMemcpy(output, h_out.data(), size * sizeof(float), cudaMemcpyHostToDevice));
 }
 

--- a/src/indicators/HT_PHASOR.cu
+++ b/src/indicators/HT_PHASOR.cu
@@ -2,46 +2,230 @@
 #include <utils/CudaUtils.h>
 #include <cuda_runtime.h>
 #include <limits>
-#include <stdexcept>
+#include <cmath>
 #include <vector>
-#include <sstream>
-#include <cstdio>
 #include <cstring>
 
-static void run_ht_phasor_python(const std::vector<float>& in, std::vector<float>& out1, std::vector<float>& out2) {
-    std::ostringstream cmd;
-    cmd << "python3 - <<'PY'\n";
-    cmd << "import numpy as np\n";
-    cmd << "try:\n import talib\nexcept Exception:\n import subprocess, sys\n subprocess.check_call([sys.executable,'-m','pip','install','-q','TA-Lib'])\n import talib\n";
-    cmd << "x=np.array([";
-    for (size_t i=0;i<in.size();++i){ if(i) cmd << ','; cmd << in[i]; }
-    cmd << "],dtype=float)\n";
-    cmd << "res=talib.HT_PHASOR(x)\n";
-    cmd << "print('\\n'.join(str(v) for v in res[0]))\n";
-    cmd << "print('---')\n";
-    cmd << "print('\\n'.join(str(v) for v in res[1]))\n";
-    cmd << "PY";
-    FILE* pipe = popen(cmd.str().c_str(), "r");
-    if(!pipe) throw std::runtime_error("popen failed");
-    char buf[256];
-    size_t idx=0;
-    bool second=false;
-    while(fgets(buf,sizeof(buf),pipe)){
-        if(strncmp(buf,"---",3)==0){ second=true; idx=0; continue; }
-        float v = std::strtof(buf,nullptr);
-        if(!second){ if(idx<out1.size()) out1[idx++] = v; }
-        else { if(idx<out2.size()) out2[idx++] = v; }
+// Port of TA-Lib's HT_PHASOR algorithm implemented purely in C++.
+static void ht_phasor_cpu(const std::vector<float>& in,
+                          std::vector<float>& outInPhase,
+                          std::vector<float>& outQuadrature) {
+    const int size = static_cast<int>(in.size());
+    const int lookbackTotal = 32; // TA-Lib lookback
+    if (size <= lookbackTotal)
+        return; // outputs remain NaN
+
+    const double a = 0.0962;
+    const double b = 0.5769;
+    const double rad2Deg = 180.0 / (4.0 * std::atan(1.0));
+
+    double period = 0.0;
+    double periodWMASub, periodWMASum, trailingWMAValue, smoothedValue;
+    double hilbertTempReal;
+    int trailingWMAIdx, hilbertIdx;
+    double Q2 = 0.0, I2 = 0.0, prevQ2 = 0.0, prevI2 = 0.0, Re = 0.0, Im = 0.0;
+    double I1ForOddPrev2 = 0.0, I1ForOddPrev3 = 0.0;
+    double I1ForEvenPrev2 = 0.0, I1ForEvenPrev3 = 0.0;
+
+    double detrender_Odd[3] = {0.0}, detrender_Even[3] = {0.0};
+    double prev_detrender_Odd = 0.0, prev_detrender_Even = 0.0;
+    double prev_detrender_input_Odd = 0.0, prev_detrender_input_Even = 0.0;
+    double detrender = 0.0;
+
+    double Q1_Odd[3] = {0.0}, Q1_Even[3] = {0.0};
+    double prev_Q1_Odd = 0.0, prev_Q1_Even = 0.0;
+    double prev_Q1_input_Odd = 0.0, prev_Q1_input_Even = 0.0;
+    double Q1 = 0.0;
+
+    double jI_Odd[3] = {0.0}, jI_Even[3] = {0.0};
+    double prev_jI_Odd = 0.0, prev_jI_Even = 0.0;
+    double prev_jI_input_Odd = 0.0, prev_jI_input_Even = 0.0;
+    double jI = 0.0;
+
+    double jQ_Odd[3] = {0.0}, jQ_Even[3] = {0.0};
+    double prev_jQ_Odd = 0.0, prev_jQ_Even = 0.0;
+    double prev_jQ_input_Odd = 0.0, prev_jQ_input_Even = 0.0;
+    double jQ = 0.0;
+
+    int startIdx = lookbackTotal;
+    int endIdx = size - 1;
+    trailingWMAIdx = startIdx - lookbackTotal;
+    int today = trailingWMAIdx;
+
+    double tempReal = in[today++];
+    periodWMASub = tempReal;
+    periodWMASum = tempReal;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 2.0;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 3.0;
+    trailingWMAValue = 0.0;
+
+    auto doPriceWMA = [&](double newPrice, double& smoothed) {
+        periodWMASub += newPrice;
+        periodWMASub -= trailingWMAValue;
+        periodWMASum += newPrice * 4.0;
+        trailingWMAValue = in[trailingWMAIdx++];
+        smoothed = periodWMASum * 0.1;
+        periodWMASum -= periodWMASub;
+    };
+
+    for (int i = 0; i < 9; ++i) {
+        tempReal = in[today++];
+        doPriceWMA(tempReal, smoothedValue);
     }
-    pclose(pipe);
+
+    hilbertIdx = 0;
+
+    while (today <= endIdx) {
+        double adjustedPrevPeriod = (0.075 * period) + 0.54;
+        double todayValue = in[today];
+        doPriceWMA(todayValue, smoothedValue);
+
+        if ((today & 1) == 0) {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Even[hilbertIdx];
+            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Even;
+            prev_detrender_Even = b * prev_detrender_input_Even;
+            detrender += prev_detrender_Even;
+            prev_detrender_input_Even = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Even[hilbertIdx];
+            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Even;
+            prev_Q1_Even = b * prev_Q1_input_Even;
+            Q1 += prev_Q1_Even;
+            prev_Q1_input_Even = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForEvenPrev3;
+            jI = -jI_Even[hilbertIdx];
+            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Even;
+            prev_jI_Even = b * prev_jI_input_Even;
+            jI += prev_jI_Even;
+            prev_jI_input_Even = I1ForEvenPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Even[hilbertIdx];
+            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Even;
+            prev_jQ_Even = b * prev_jQ_input_Even;
+            jQ += prev_jQ_Even;
+            prev_jQ_input_Even = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForEvenPrev3 - jQ)) + (0.8 * prevI2);
+
+            if (today >= startIdx) {
+                outQuadrature[today] = static_cast<float>(Q1);
+                outInPhase[today] = static_cast<float>(I1ForEvenPrev3);
+            }
+
+            I1ForOddPrev3 = I1ForOddPrev2;
+            I1ForOddPrev2 = detrender;
+        } else {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Odd[hilbertIdx];
+            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Odd;
+            prev_detrender_Odd = b * prev_detrender_input_Odd;
+            detrender += prev_detrender_Odd;
+            prev_detrender_input_Odd = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Odd[hilbertIdx];
+            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Odd;
+            prev_Q1_Odd = b * prev_Q1_input_Odd;
+            Q1 += prev_Q1_Odd;
+            prev_Q1_input_Odd = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForOddPrev3;
+            jI = -jI_Odd[hilbertIdx];
+            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Odd;
+            prev_jI_Odd = b * prev_jI_input_Odd;
+            jI += prev_jI_Odd;
+            prev_jI_input_Odd = I1ForOddPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Odd[hilbertIdx];
+            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Odd;
+            prev_jQ_Odd = b * prev_jQ_input_Odd;
+            jQ += prev_jQ_Odd;
+            prev_jQ_input_Odd = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForOddPrev3 - jQ)) + (0.8 * prevI2);
+
+            if (today >= startIdx) {
+                outQuadrature[today] = static_cast<float>(Q1);
+                outInPhase[today] = static_cast<float>(I1ForOddPrev3);
+            }
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            I1ForEvenPrev3 = I1ForEvenPrev2;
+            I1ForEvenPrev2 = detrender;
+        }
+
+        Re = (0.2 * ((I2 * prevI2) + (Q2 * prevQ2))) + (0.8 * Re);
+        Im = (0.2 * ((I2 * prevQ2) - (Q2 * prevI2))) + (0.8 * Im);
+        prevQ2 = Q2;
+        prevI2 = I2;
+        double temp = period;
+        if ((Im != 0.0) && (Re != 0.0))
+            period = 360.0 / (std::atan(Im / Re) * rad2Deg);
+        double temp2 = 1.5 * temp;
+        if (period > temp2)
+            period = temp2;
+        temp2 = 0.67 * temp;
+        if (period < temp2)
+            period = temp2;
+        if (period < 6)
+            period = 6;
+        else if (period > 50)
+            period = 50;
+        period = (0.2 * period) + (0.8 * temp);
+
+        today++;
+    }
 }
 
 void HT_PHASOR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
-    std::vector<float> h_in(size), inphase(size, std::numeric_limits<float>::quiet_NaN()), quadrature(size, std::numeric_limits<float>::quiet_NaN());
-    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size*sizeof(float), cudaMemcpyDeviceToHost));
-    run_ht_phasor_python(h_in, inphase, quadrature);
-    std::vector<float> combined(size*2);
-    std::memcpy(combined.data(), inphase.data(), size*sizeof(float));
-    std::memcpy(combined.data()+size, quadrature.data(), size*sizeof(float));
-    CUDA_CHECK(cudaMemcpy(output, combined.data(), size*2*sizeof(float), cudaMemcpyHostToDevice));
+    std::vector<float> h_in(size);
+    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
+    std::vector<float> inphase(size, std::numeric_limits<float>::quiet_NaN());
+    std::vector<float> quadrature(size, std::numeric_limits<float>::quiet_NaN());
+    ht_phasor_cpu(h_in, inphase, quadrature);
+    std::vector<float> combined(size * 2);
+    std::memcpy(combined.data(), inphase.data(), size * sizeof(float));
+    std::memcpy(combined.data() + size, quadrature.data(), size * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(output, combined.data(), size * 2 * sizeof(float), cudaMemcpyHostToDevice));
 }
 

--- a/src/indicators/HT_SINE.cu
+++ b/src/indicators/HT_SINE.cu
@@ -2,45 +2,268 @@
 #include <utils/CudaUtils.h>
 #include <cuda_runtime.h>
 #include <limits>
-#include <stdexcept>
+#include <cmath>
 #include <vector>
-#include <sstream>
-#include <cstdio>
 #include <cstring>
 
-static void run_ht_sine_python(const std::vector<float>& in, std::vector<float>& out1, std::vector<float>& out2) {
-    std::ostringstream cmd;
-    cmd << "python3 - <<'PY'\n";
-    cmd << "import numpy as np\n";
-    cmd << "try:\n import talib\nexcept Exception:\n import subprocess, sys\n subprocess.check_call([sys.executable,'-m','pip','install','-q','TA-Lib'])\n import talib\n";
-    cmd << "x=np.array([";
-    for(size_t i=0;i<in.size();++i){ if(i) cmd << ','; cmd << in[i]; }
-    cmd << "],dtype=float)\n";
-    cmd << "res=talib.HT_SINE(x)\n";
-    cmd << "print('\\n'.join(str(v) for v in res[0]))\n";
-    cmd << "print('---')\n";
-    cmd << "print('\\n'.join(str(v) for v in res[1]))\n";
-    cmd << "PY";
-    FILE* pipe = popen(cmd.str().c_str(), "r");
-    if(!pipe) throw std::runtime_error("popen failed");
-    char buf[256];
-    size_t idx=0; bool second=false;
-    while(fgets(buf,sizeof(buf),pipe)){
-        if(strncmp(buf,"---",3)==0){ second=true; idx=0; continue; }
-        float v = std::strtof(buf,nullptr);
-        if(!second){ if(idx<out1.size()) out1[idx++] = v; }
-        else { if(idx<out2.size()) out2[idx++] = v; }
+// Port of TA-Lib's HT_SINE directly in C++.
+static void ht_sine_cpu(const std::vector<float>& in,
+                        std::vector<float>& outSine,
+                        std::vector<float>& outLead) {
+    const int size = static_cast<int>(in.size());
+    const int lookbackTotal = 63;
+    if (size <= lookbackTotal)
+        return;
+
+    const double a = 0.0962;
+    const double b = 0.5769;
+    const double tempPI = std::atan(1.0);
+    const double rad2Deg = 45.0 / tempPI;
+    const double deg2Rad = 1.0 / rad2Deg;
+    const double constDeg2RadBy360 = tempPI * 8.0;
+
+    double period = 0.0, smoothPeriod = 0.0;
+    double periodWMASub, periodWMASum, trailingWMAValue, smoothedValue;
+    double hilbertTempReal;
+    int trailingWMAIdx, hilbertIdx;
+    double Q2 = 0.0, I2 = 0.0, prevQ2 = 0.0, prevI2 = 0.0, Re = 0.0, Im = 0.0;
+    double I1ForOddPrev2 = 0.0, I1ForOddPrev3 = 0.0;
+    double I1ForEvenPrev2 = 0.0, I1ForEvenPrev3 = 0.0;
+
+    double detrender_Odd[3] = {0.0}, detrender_Even[3] = {0.0};
+    double prev_detrender_Odd = 0.0, prev_detrender_Even = 0.0;
+    double prev_detrender_input_Odd = 0.0, prev_detrender_input_Even = 0.0;
+    double detrender = 0.0;
+
+    double Q1_Odd[3] = {0.0}, Q1_Even[3] = {0.0};
+    double prev_Q1_Odd = 0.0, prev_Q1_Even = 0.0;
+    double prev_Q1_input_Odd = 0.0, prev_Q1_input_Even = 0.0;
+    double Q1 = 0.0;
+
+    double jI_Odd[3] = {0.0}, jI_Even[3] = {0.0};
+    double prev_jI_Odd = 0.0, prev_jI_Even = 0.0;
+    double prev_jI_input_Odd = 0.0, prev_jI_input_Even = 0.0;
+    double jI = 0.0;
+
+    double jQ_Odd[3] = {0.0}, jQ_Even[3] = {0.0};
+    double prev_jQ_Odd = 0.0, prev_jQ_Even = 0.0;
+    double prev_jQ_input_Odd = 0.0, prev_jQ_input_Even = 0.0;
+    double jQ = 0.0;
+
+    std::vector<double> smoothPrice(50, 0.0);
+    int smoothPrice_Idx = 0;
+
+    int startIdx = lookbackTotal;
+    int endIdx = size - 1;
+    trailingWMAIdx = startIdx - lookbackTotal;
+    int today = trailingWMAIdx;
+
+    double tempReal = in[today++];
+    periodWMASub = tempReal;
+    periodWMASum = tempReal;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 2.0;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 3.0;
+    trailingWMAValue = 0.0;
+
+    auto doPriceWMA = [&](double newPrice, double& smoothed) {
+        periodWMASub += newPrice;
+        periodWMASub -= trailingWMAValue;
+        periodWMASum += newPrice * 4.0;
+        trailingWMAValue = in[trailingWMAIdx++];
+        smoothed = periodWMASum * 0.1;
+        periodWMASum -= periodWMASub;
+    };
+
+    for (int i = 0; i < 34; ++i) {
+        tempReal = in[today++];
+        doPriceWMA(tempReal, smoothedValue);
     }
-    pclose(pipe);
+
+    hilbertIdx = 0;
+
+    while (today <= endIdx) {
+        double adjustedPrevPeriod = (0.075 * period) + 0.54;
+        double todayValue = in[today];
+        doPriceWMA(todayValue, smoothedValue);
+        smoothPrice[smoothPrice_Idx] = smoothedValue;
+
+        if ((today & 1) == 0) {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Even[hilbertIdx];
+            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Even;
+            prev_detrender_Even = b * prev_detrender_input_Even;
+            detrender += prev_detrender_Even;
+            prev_detrender_input_Even = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Even[hilbertIdx];
+            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Even;
+            prev_Q1_Even = b * prev_Q1_input_Even;
+            Q1 += prev_Q1_Even;
+            prev_Q1_input_Even = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForEvenPrev3;
+            jI = -jI_Even[hilbertIdx];
+            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Even;
+            prev_jI_Even = b * prev_jI_input_Even;
+            jI += prev_jI_Even;
+            prev_jI_input_Even = I1ForEvenPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Even[hilbertIdx];
+            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Even;
+            prev_jQ_Even = b * prev_jQ_input_Even;
+            jQ += prev_jQ_Even;
+            prev_jQ_input_Even = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForEvenPrev3 - jQ)) + (0.8 * prevI2);
+
+            I1ForOddPrev3 = I1ForOddPrev2;
+            I1ForOddPrev2 = detrender;
+        } else {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Odd[hilbertIdx];
+            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Odd;
+            prev_detrender_Odd = b * prev_detrender_input_Odd;
+            detrender += prev_detrender_Odd;
+            prev_detrender_input_Odd = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Odd[hilbertIdx];
+            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Odd;
+            prev_Q1_Odd = b * prev_Q1_input_Odd;
+            Q1 += prev_Q1_Odd;
+            prev_Q1_input_Odd = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForOddPrev3;
+            jI = -jI_Odd[hilbertIdx];
+            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Odd;
+            prev_jI_Odd = b * prev_jI_input_Odd;
+            jI += prev_jI_Odd;
+            prev_jI_input_Odd = I1ForOddPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Odd[hilbertIdx];
+            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Odd;
+            prev_jQ_Odd = b * prev_jQ_input_Odd;
+            jQ += prev_jQ_Odd;
+            prev_jQ_input_Odd = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForOddPrev3 - jQ)) + (0.8 * prevI2);
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            I1ForEvenPrev3 = I1ForEvenPrev2;
+            I1ForEvenPrev2 = detrender;
+        }
+
+        Re = (0.2 * ((I2 * prevI2) + (Q2 * prevQ2))) + (0.8 * Re);
+        Im = (0.2 * ((I2 * prevQ2) - (Q2 * prevI2))) + (0.8 * Im);
+        prevQ2 = Q2;
+        prevI2 = I2;
+        double temp = period;
+        if ((Im != 0.0) && (Re != 0.0))
+            period = 360.0 / (std::atan(Im / Re) * rad2Deg);
+        double temp2 = 1.5 * temp;
+        if (period > temp2) period = temp2;
+        temp2 = 0.67 * temp;
+        if (period < temp2) period = temp2;
+        if (period < 6) period = 6;
+        else if (period > 50) period = 50;
+        period = (0.2 * period) + (0.8 * temp);
+        smoothPeriod = (0.33 * period) + (0.67 * smoothPeriod);
+
+        double DCPeriod = smoothPeriod + 0.5;
+        int DCPeriodInt = static_cast<int>(DCPeriod);
+        double realPart = 0.0, imagPart = 0.0;
+        int idx = smoothPrice_Idx;
+        for (int i = 0; i < DCPeriodInt; ++i) {
+            double phase = (i * constDeg2RadBy360) / DCPeriodInt;
+            double cosVal = std::cos(phase);
+            double sinVal = std::sin(phase);
+            double tempPrice = smoothPrice[idx];
+            realPart += sinVal * tempPrice;
+            imagPart += cosVal * tempPrice;
+            if (idx == 0)
+                idx = 49;
+            else
+                idx--;
+        }
+        double DCPhase;
+        double absImag = std::fabs(imagPart);
+        if (absImag > 0.0)
+            DCPhase = std::atan(realPart / imagPart) * rad2Deg;
+        else if (absImag <= 0.01) {
+            if (realPart < 0.0)
+                DCPhase = -90.0;
+            else if (realPart > 0.0)
+                DCPhase = 90.0;
+            else
+                DCPhase = 0.0;
+        } else {
+            DCPhase = 0.0;
+        }
+        DCPhase += 90.0;
+        DCPhase += 360.0 / smoothPeriod;
+        if (imagPart < 0.0)
+            DCPhase += 180.0;
+        if (DCPhase > 315.0)
+            DCPhase -= 360.0;
+
+        if (today >= startIdx) {
+            outSine[today] = static_cast<float>(std::sin(DCPhase * deg2Rad));
+            outLead[today] = static_cast<float>(std::sin((DCPhase + 45.0) * deg2Rad));
+        }
+
+        if (++smoothPrice_Idx == 50)
+            smoothPrice_Idx = 0;
+        today++;
+    }
 }
 
 void HT_SINE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
-    std::vector<float> h_in(size), sine(size, std::numeric_limits<float>::quiet_NaN()), lead(size, std::numeric_limits<float>::quiet_NaN());
-    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size*sizeof(float), cudaMemcpyDeviceToHost));
-    run_ht_sine_python(h_in, sine, lead);
-    std::vector<float> combined(size*2);
-    std::memcpy(combined.data(), sine.data(), size*sizeof(float));
-    std::memcpy(combined.data()+size, lead.data(), size*sizeof(float));
-    CUDA_CHECK(cudaMemcpy(output, combined.data(), size*2*sizeof(float), cudaMemcpyHostToDevice));
+    std::vector<float> h_in(size);
+    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
+    std::vector<float> sine(size, std::numeric_limits<float>::quiet_NaN());
+    std::vector<float> lead(size, std::numeric_limits<float>::quiet_NaN());
+    ht_sine_cpu(h_in, sine, lead);
+    std::vector<float> combined(size * 2);
+    std::memcpy(combined.data(), sine.data(), size * sizeof(float));
+    std::memcpy(combined.data() + size, lead.data(), size * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(output, combined.data(), size * 2 * sizeof(float), cudaMemcpyHostToDevice));
 }
 

--- a/src/indicators/HT_TRENDLINE.cu
+++ b/src/indicators/HT_TRENDLINE.cu
@@ -2,36 +2,229 @@
 #include <utils/CudaUtils.h>
 #include <cuda_runtime.h>
 #include <limits>
-#include <stdexcept>
+#include <cmath>
 #include <vector>
-#include <sstream>
-#include <cstdio>
 
-static void run_ht_trendline_python(const std::vector<float>& in, std::vector<float>& out) {
-    std::ostringstream cmd;
-    cmd << "python3 - <<'PY'\n";
-    cmd << "import numpy as np\n";
-    cmd << "try:\n import talib\nexcept Exception:\n import subprocess, sys\n "
-           "subprocess.check_call([sys.executable,'-m','pip','install','-q','TA-Lib'])\n import talib\n";
-    cmd << "x=np.array([";
-    for(size_t i=0;i<in.size();++i){ if(i) cmd << ','; cmd << in[i]; }
-    cmd << "],dtype=float)\n";
-    cmd << "res=talib.HT_TRENDLINE(x)\n";
-    cmd << "print('\\n'.join(str(v) for v in res))\n";
-    cmd << "PY";
-    FILE* pipe = popen(cmd.str().c_str(), "r");
-    if(!pipe) throw std::runtime_error("popen failed");
-    char buf[256]; size_t idx=0;
-    while(idx<out.size() && fgets(buf,sizeof(buf),pipe)){
-        out[idx++] = std::strtof(buf,nullptr);
+// Port of TA-Lib's HT_TRENDLINE implemented in C++.
+static void ht_trendline_cpu(const std::vector<float>& in, std::vector<float>& out) {
+    const int size = static_cast<int>(in.size());
+    const int lookbackTotal = 63;
+    if (size <= lookbackTotal)
+        return;
+
+    const double a = 0.0962;
+    const double b = 0.5769;
+    const double rad2Deg = 180.0 / (4.0 * std::atan(1.0));
+
+    double period = 0.0, smoothPeriod = 0.0;
+    double periodWMASub, periodWMASum, trailingWMAValue, smoothedValue;
+    double hilbertTempReal;
+    int trailingWMAIdx, hilbertIdx;
+    double Q2 = 0.0, I2 = 0.0, prevQ2 = 0.0, prevI2 = 0.0, Re = 0.0, Im = 0.0;
+    double I1ForOddPrev2 = 0.0, I1ForOddPrev3 = 0.0;
+    double I1ForEvenPrev2 = 0.0, I1ForEvenPrev3 = 0.0;
+
+    double detrender_Odd[3] = {0.0}, detrender_Even[3] = {0.0};
+    double prev_detrender_Odd = 0.0, prev_detrender_Even = 0.0;
+    double prev_detrender_input_Odd = 0.0, prev_detrender_input_Even = 0.0;
+    double detrender = 0.0;
+
+    double Q1_Odd[3] = {0.0}, Q1_Even[3] = {0.0};
+    double prev_Q1_Odd = 0.0, prev_Q1_Even = 0.0;
+    double prev_Q1_input_Odd = 0.0, prev_Q1_input_Even = 0.0;
+    double Q1 = 0.0;
+
+    double jI_Odd[3] = {0.0}, jI_Even[3] = {0.0};
+    double prev_jI_Odd = 0.0, prev_jI_Even = 0.0;
+    double prev_jI_input_Odd = 0.0, prev_jI_input_Even = 0.0;
+    double jI = 0.0;
+
+    double jQ_Odd[3] = {0.0}, jQ_Even[3] = {0.0};
+    double prev_jQ_Odd = 0.0, prev_jQ_Even = 0.0;
+    double prev_jQ_input_Odd = 0.0, prev_jQ_input_Even = 0.0;
+    double jQ = 0.0;
+
+    double iTrend1 = 0.0, iTrend2 = 0.0, iTrend3 = 0.0;
+
+    int startIdx = lookbackTotal;
+    int endIdx = size - 1;
+    trailingWMAIdx = startIdx - lookbackTotal;
+    int today = trailingWMAIdx;
+
+    double tempReal = in[today++];
+    periodWMASub = tempReal;
+    periodWMASum = tempReal;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 2.0;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 3.0;
+    trailingWMAValue = 0.0;
+
+    auto doPriceWMA = [&](double newPrice, double& smoothed) {
+        periodWMASub += newPrice;
+        periodWMASub -= trailingWMAValue;
+        periodWMASum += newPrice * 4.0;
+        trailingWMAValue = in[trailingWMAIdx++];
+        smoothed = periodWMASum * 0.1;
+        periodWMASum -= periodWMASub;
+    };
+
+    for (int i = 0; i < 34; ++i) {
+        tempReal = in[today++];
+        doPriceWMA(tempReal, smoothedValue);
     }
-    pclose(pipe);
+
+    hilbertIdx = 0;
+
+    while (today <= endIdx) {
+        double adjustedPrevPeriod = (0.075 * period) + 0.54;
+        double todayValue = in[today];
+        doPriceWMA(todayValue, smoothedValue);
+
+        if ((today & 1) == 0) {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Even[hilbertIdx];
+            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Even;
+            prev_detrender_Even = b * prev_detrender_input_Even;
+            detrender += prev_detrender_Even;
+            prev_detrender_input_Even = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Even[hilbertIdx];
+            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Even;
+            prev_Q1_Even = b * prev_Q1_input_Even;
+            Q1 += prev_Q1_Even;
+            prev_Q1_input_Even = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForEvenPrev3;
+            jI = -jI_Even[hilbertIdx];
+            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Even;
+            prev_jI_Even = b * prev_jI_input_Even;
+            jI += prev_jI_Even;
+            prev_jI_input_Even = I1ForEvenPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Even[hilbertIdx];
+            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Even;
+            prev_jQ_Even = b * prev_jQ_input_Even;
+            jQ += prev_jQ_Even;
+            prev_jQ_input_Even = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForEvenPrev3 - jQ)) + (0.8 * prevI2);
+
+            I1ForOddPrev3 = I1ForOddPrev2;
+            I1ForOddPrev2 = detrender;
+        } else {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Odd[hilbertIdx];
+            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Odd;
+            prev_detrender_Odd = b * prev_detrender_input_Odd;
+            detrender += prev_detrender_Odd;
+            prev_detrender_input_Odd = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Odd[hilbertIdx];
+            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Odd;
+            prev_Q1_Odd = b * prev_Q1_input_Odd;
+            Q1 += prev_Q1_Odd;
+            prev_Q1_input_Odd = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForOddPrev3;
+            jI = -jI_Odd[hilbertIdx];
+            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Odd;
+            prev_jI_Odd = b * prev_jI_input_Odd;
+            jI += prev_jI_Odd;
+            prev_jI_input_Odd = I1ForOddPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Odd[hilbertIdx];
+            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Odd;
+            prev_jQ_Odd = b * prev_jQ_input_Odd;
+            jQ += prev_jQ_Odd;
+            prev_jQ_input_Odd = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForOddPrev3 - jQ)) + (0.8 * prevI2);
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            I1ForEvenPrev3 = I1ForEvenPrev2;
+            I1ForEvenPrev2 = detrender;
+        }
+
+        Re = (0.2 * ((I2 * prevI2) + (Q2 * prevQ2))) + (0.8 * Re);
+        Im = (0.2 * ((I2 * prevQ2) - (Q2 * prevI2))) + (0.8 * Im);
+        prevQ2 = Q2;
+        prevI2 = I2;
+        double temp = period;
+        if ((Im != 0.0) && (Re != 0.0))
+            period = 360.0 / (std::atan(Im / Re) * rad2Deg);
+        double temp2 = 1.5 * temp;
+        if (period > temp2) period = temp2;
+        temp2 = 0.67 * temp;
+        if (period < temp2) period = temp2;
+        if (period < 6) period = 6;
+        else if (period > 50) period = 50;
+        period = (0.2 * period) + (0.8 * temp);
+        smoothPeriod = (0.33 * period) + (0.67 * smoothPeriod);
+
+        double DCPeriod = smoothPeriod + 0.5;
+        int DCPeriodInt = static_cast<int>(DCPeriod);
+        double avgPrice = 0.0;
+        int idx = today;
+        for (int i = 0; i < DCPeriodInt; ++i)
+            avgPrice += in[idx--];
+        if (DCPeriodInt > 0)
+            avgPrice /= DCPeriodInt;
+
+        double trend = (4.0 * avgPrice + 3.0 * iTrend1 + 2.0 * iTrend2 + iTrend3) / 10.0;
+        iTrend3 = iTrend2;
+        iTrend2 = iTrend1;
+        iTrend1 = avgPrice;
+
+        if (today >= startIdx)
+            out[today] = static_cast<float>(trend);
+
+        today++;
+    }
 }
 
 void HT_TRENDLINE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
-    std::vector<float> h_in(size), h_out(size, std::numeric_limits<float>::quiet_NaN());
-    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size*sizeof(float), cudaMemcpyDeviceToHost));
-    run_ht_trendline_python(h_in, h_out);
-    CUDA_CHECK(cudaMemcpy(output, h_out.data(), size*sizeof(float), cudaMemcpyHostToDevice));
+    std::vector<float> h_in(size);
+    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
+    std::vector<float> h_out(size, std::numeric_limits<float>::quiet_NaN());
+    ht_trendline_cpu(h_in, h_out);
+    CUDA_CHECK(cudaMemcpy(output, h_out.data(), size * sizeof(float), cudaMemcpyHostToDevice));
 }
 

--- a/src/indicators/HT_TRENDMODE.cu
+++ b/src/indicators/HT_TRENDMODE.cu
@@ -2,35 +2,301 @@
 #include <utils/CudaUtils.h>
 #include <cuda_runtime.h>
 #include <limits>
-#include <stdexcept>
+#include <cmath>
 #include <vector>
-#include <sstream>
-#include <cstdio>
 
-static void run_ht_trendmode_python(const std::vector<float>& in, std::vector<float>& out) {
-    std::ostringstream cmd;
-    cmd << "python3 - <<'PY'\n";
-    cmd << "import numpy as np\n";
-    cmd << "try:\n import talib\nexcept Exception:\n import subprocess, sys\n subprocess.check_call([sys.executable,'-m','pip','install','-q','TA-Lib'])\n import talib\n";
-    cmd << "x=np.array([";
-    for(size_t i=0;i<in.size();++i){ if(i) cmd << ','; cmd << in[i]; }
-    cmd << "],dtype=float)\n";
-    cmd << "res=talib.HT_TRENDMODE(x)\n";
-    cmd << "print('\\n'.join(str(v) for v in res))\n";
-    cmd << "PY";
-    FILE* pipe = popen(cmd.str().c_str(), "r");
-    if(!pipe) throw std::runtime_error("popen failed");
-    char buf[256]; size_t idx=0;
-    while(idx<out.size() && fgets(buf,sizeof(buf),pipe)){
-        out[idx++] = std::strtof(buf,nullptr);
+// Port of TA-Lib's HT_TRENDMODE in C++.
+static void ht_trendmode_cpu(const std::vector<float>& in, std::vector<int>& out) {
+    const int size = static_cast<int>(in.size());
+    const int lookbackTotal = 63;
+    if (size <= lookbackTotal)
+        return;
+
+    const double a = 0.0962;
+    const double b = 0.5769;
+    const double tempPI = std::atan(1.0);
+    const double rad2Deg = 45.0 / tempPI;
+    const double deg2Rad = 1.0 / rad2Deg;
+    const double constDeg2RadBy360 = tempPI * 8.0;
+
+    double period = 0.0, smoothPeriod = 0.0;
+    double periodWMASub, periodWMASum, trailingWMAValue, smoothedValue;
+    double hilbertTempReal;
+    int trailingWMAIdx, hilbertIdx;
+    double Q2 = 0.0, I2 = 0.0, prevQ2 = 0.0, prevI2 = 0.0, Re = 0.0, Im = 0.0;
+    double I1ForOddPrev2 = 0.0, I1ForOddPrev3 = 0.0;
+    double I1ForEvenPrev2 = 0.0, I1ForEvenPrev3 = 0.0;
+
+    double detrender_Odd[3] = {0.0}, detrender_Even[3] = {0.0};
+    double prev_detrender_Odd = 0.0, prev_detrender_Even = 0.0;
+    double prev_detrender_input_Odd = 0.0, prev_detrender_input_Even = 0.0;
+    double detrender = 0.0;
+
+    double Q1_Odd[3] = {0.0}, Q1_Even[3] = {0.0};
+    double prev_Q1_Odd = 0.0, prev_Q1_Even = 0.0;
+    double prev_Q1_input_Odd = 0.0, prev_Q1_input_Even = 0.0;
+    double Q1 = 0.0;
+
+    double jI_Odd[3] = {0.0}, jI_Even[3] = {0.0};
+    double prev_jI_Odd = 0.0, prev_jI_Even = 0.0;
+    double prev_jI_input_Odd = 0.0, prev_jI_input_Even = 0.0;
+    double jI = 0.0;
+
+    double jQ_Odd[3] = {0.0}, jQ_Even[3] = {0.0};
+    double prev_jQ_Odd = 0.0, prev_jQ_Even = 0.0;
+    double prev_jQ_input_Odd = 0.0, prev_jQ_input_Even = 0.0;
+    double jQ = 0.0;
+
+    std::vector<double> smoothPrice(50, 0.0);
+    int smoothPrice_Idx = 0;
+
+    double iTrend1 = 0.0, iTrend2 = 0.0, iTrend3 = 0.0;
+    int daysInTrend = 0, trend = 0;
+    double prevDCPhase = 0.0;
+    double prevSine = 0.0, prevLeadSine = 0.0, sine = 0.0, leadSine = 0.0;
+
+    int startIdx = lookbackTotal;
+    int endIdx = size - 1;
+    trailingWMAIdx = startIdx - lookbackTotal;
+    int today = trailingWMAIdx;
+
+    double tempReal = in[today++];
+    periodWMASub = tempReal;
+    periodWMASum = tempReal;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 2.0;
+    tempReal = in[today++];
+    periodWMASub += tempReal;
+    periodWMASum += tempReal * 3.0;
+    trailingWMAValue = 0.0;
+
+    auto doPriceWMA = [&](double newPrice, double& smoothed) {
+        periodWMASub += newPrice;
+        periodWMASub -= trailingWMAValue;
+        periodWMASum += newPrice * 4.0;
+        trailingWMAValue = in[trailingWMAIdx++];
+        smoothed = periodWMASum * 0.1;
+        periodWMASum -= periodWMASub;
+    };
+
+    for (int i = 0; i < 34; ++i) {
+        tempReal = in[today++];
+        doPriceWMA(tempReal, smoothedValue);
     }
-    pclose(pipe);
+
+    hilbertIdx = 0;
+
+    while (today <= endIdx) {
+        double adjustedPrevPeriod = (0.075 * period) + 0.54;
+        double todayValue = in[today];
+        doPriceWMA(todayValue, smoothedValue);
+        smoothPrice[smoothPrice_Idx] = smoothedValue;
+
+        if ((today & 1) == 0) {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Even[hilbertIdx];
+            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Even;
+            prev_detrender_Even = b * prev_detrender_input_Even;
+            detrender += prev_detrender_Even;
+            prev_detrender_input_Even = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Even[hilbertIdx];
+            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Even;
+            prev_Q1_Even = b * prev_Q1_input_Even;
+            Q1 += prev_Q1_Even;
+            prev_Q1_input_Even = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForEvenPrev3;
+            jI = -jI_Even[hilbertIdx];
+            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Even;
+            prev_jI_Even = b * prev_jI_input_Even;
+            jI += prev_jI_Even;
+            prev_jI_input_Even = I1ForEvenPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Even[hilbertIdx];
+            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Even;
+            prev_jQ_Even = b * prev_jQ_input_Even;
+            jQ += prev_jQ_Even;
+            prev_jQ_input_Even = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForEvenPrev3 - jQ)) + (0.8 * prevI2);
+
+            I1ForOddPrev3 = I1ForOddPrev2;
+            I1ForOddPrev2 = detrender;
+        } else {
+            hilbertTempReal = a * smoothedValue;
+            detrender = -detrender_Odd[hilbertIdx];
+            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender += hilbertTempReal;
+            detrender -= prev_detrender_Odd;
+            prev_detrender_Odd = b * prev_detrender_input_Odd;
+            detrender += prev_detrender_Odd;
+            prev_detrender_input_Odd = smoothedValue;
+            detrender *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * detrender;
+            Q1 = -Q1_Odd[hilbertIdx];
+            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 += hilbertTempReal;
+            Q1 -= prev_Q1_Odd;
+            prev_Q1_Odd = b * prev_Q1_input_Odd;
+            Q1 += prev_Q1_Odd;
+            prev_Q1_input_Odd = detrender;
+            Q1 *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * I1ForOddPrev3;
+            jI = -jI_Odd[hilbertIdx];
+            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI += hilbertTempReal;
+            jI -= prev_jI_Odd;
+            prev_jI_Odd = b * prev_jI_input_Odd;
+            jI += prev_jI_Odd;
+            prev_jI_input_Odd = I1ForOddPrev3;
+            jI *= adjustedPrevPeriod;
+
+            hilbertTempReal = a * Q1;
+            jQ = -jQ_Odd[hilbertIdx];
+            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ += hilbertTempReal;
+            jQ -= prev_jQ_Odd;
+            prev_jQ_Odd = b * prev_jQ_input_Odd;
+            jQ += prev_jQ_Odd;
+            prev_jQ_input_Odd = Q1;
+            jQ *= adjustedPrevPeriod;
+
+            Q2 = (0.2 * (Q1 + jI)) + (0.8 * prevQ2);
+            I2 = (0.2 * (I1ForOddPrev3 - jQ)) + (0.8 * prevI2);
+
+            if (++hilbertIdx == 3)
+                hilbertIdx = 0;
+
+            I1ForEvenPrev3 = I1ForEvenPrev2;
+            I1ForEvenPrev2 = detrender;
+        }
+
+        Re = (0.2 * ((I2 * prevI2) + (Q2 * prevQ2))) + (0.8 * Re);
+        Im = (0.2 * ((I2 * prevQ2) - (Q2 * prevI2))) + (0.8 * Im);
+        prevQ2 = Q2;
+        prevI2 = I2;
+        double temp = period;
+        if ((Im != 0.0) && (Re != 0.0))
+            period = 360.0 / (std::atan(Im / Re) * rad2Deg);
+        double temp2 = 1.5 * temp;
+        if (period > temp2) period = temp2;
+        temp2 = 0.67 * temp;
+        if (period < temp2) period = temp2;
+        if (period < 6) period = 6;
+        else if (period > 50) period = 50;
+        period = (0.2 * period) + (0.8 * temp);
+        smoothPeriod = (0.33 * period) + (0.67 * smoothPeriod);
+
+        double DCPeriod = smoothPeriod + 0.5;
+        int DCPeriodInt = static_cast<int>(DCPeriod);
+        double realPart = 0.0, imagPart = 0.0;
+        int idx = smoothPrice_Idx;
+        for (int i = 0; i < DCPeriodInt; ++i) {
+            double phase = (i * constDeg2RadBy360) / DCPeriodInt;
+            double cosVal = std::cos(phase);
+            double sinVal = std::sin(phase);
+            double tempPrice = smoothPrice[idx];
+            realPart += sinVal * tempPrice;
+            imagPart += cosVal * tempPrice;
+            if (idx == 0)
+                idx = 49;
+            else
+                idx--;
+        }
+        double DCPhase;
+        double absImag = std::fabs(imagPart);
+        if (absImag > 0.0)
+            DCPhase = std::atan(realPart / imagPart) * rad2Deg;
+        else if (absImag <= 0.01) {
+            if (realPart < 0.0)
+                DCPhase = -90.0;
+            else if (realPart > 0.0)
+                DCPhase = 90.0;
+            else
+                DCPhase = 0.0;
+        } else {
+            DCPhase = 0.0;
+        }
+        DCPhase += 90.0;
+        DCPhase += 360.0 / smoothPeriod;
+        if (imagPart < 0.0)
+            DCPhase += 180.0;
+        if (DCPhase > 315.0)
+            DCPhase -= 360.0;
+
+        prevSine = sine;
+        prevLeadSine = leadSine;
+        sine = std::sin(DCPhase * deg2Rad);
+        leadSine = std::sin((DCPhase + 45.0) * deg2Rad);
+
+        DCPeriod = smoothPeriod + 0.5;
+        DCPeriodInt = static_cast<int>(DCPeriod);
+        double avgPrice = 0.0;
+        int idx2 = today;
+        for (int i = 0; i < DCPeriodInt; ++i)
+            avgPrice += in[idx2--];
+        if (DCPeriodInt > 0)
+            avgPrice /= DCPeriodInt;
+        double trendline = (4.0 * avgPrice + 3.0 * iTrend1 + 2.0 * iTrend2 + iTrend3) / 10.0;
+        iTrend3 = iTrend2;
+        iTrend2 = iTrend1;
+        iTrend1 = avgPrice;
+
+        trend = 1;
+        if (((sine > leadSine) && (prevSine <= prevLeadSine)) ||
+            ((sine < leadSine) && (prevSine >= prevLeadSine))) {
+            daysInTrend = 0;
+            trend = 0;
+        }
+        daysInTrend++;
+        if (daysInTrend < (0.5 * smoothPeriod))
+            trend = 0;
+        tempReal = DCPhase - prevDCPhase;
+        if ((smoothPeriod != 0.0) &&
+            (tempReal > (0.67 * 360.0 / smoothPeriod)) &&
+            (tempReal < (1.5 * 360.0 / smoothPeriod)))
+            trend = 0;
+        tempReal = smoothPrice[smoothPrice_Idx];
+        if ((trendline != 0.0) && (std::fabs((tempReal - trendline) / trendline) >= 0.015))
+            trend = 1;
+
+        if (today >= startIdx)
+            out[today] = trend;
+
+        prevDCPhase = DCPhase;
+        if (++smoothPrice_Idx == 50)
+            smoothPrice_Idx = 0;
+        today++;
+    }
 }
 
 void HT_TRENDMODE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
-    std::vector<float> h_in(size), h_out(size, std::numeric_limits<float>::quiet_NaN());
-    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size*sizeof(float), cudaMemcpyDeviceToHost));
-    run_ht_trendmode_python(h_in, h_out);
-    CUDA_CHECK(cudaMemcpy(output, h_out.data(), size*sizeof(float), cudaMemcpyHostToDevice));
+    std::vector<float> h_in(size);
+    CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
+    std::vector<int> h_out(size, 0);
+    ht_trendmode_cpu(h_in, h_out);
+    CUDA_CHECK(cudaMemcpy(output, h_out.data(), size * sizeof(int), cudaMemcpyHostToDevice));
 }
 


### PR DESCRIPTION
## Summary
- Port HT_PHASOR, HT_DCPHASE, HT_SINE, HT_TRENDLINE, and HT_TRENDMODE to C++ based on TA-Lib algorithms
- Eliminate all runtime Python interpreter calls from Hilbert transform indicators

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*


------
https://chatgpt.com/codex/tasks/task_e_68aa58c4d9f483298ea958b4404bd0c1