### PR TITLE
Use cudaMemsetAsync for indicator output initialization

### DIFF
--- a/src/indicators/ADOSC.cu
+++ b/src/indicators/ADOSC.cu
@@ -66,7 +66,7 @@ void ADOSC::calculate(const float* high, const float* low, const float* close,
 
     adLineKernel<<<1, 1, 0, stream>>>(high, low, close, volume, ad.get(), size);
     CUDA_CHECK(cudaGetLastError());
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     adoscKernel<<<grid, block, 0, stream>>>(ad.get(), output, shortPeriod, longPeriod, size);

--- a/src/indicators/ADX.cu
+++ b/src/indicators/ADX.cu
@@ -75,7 +75,7 @@ void ADX::calculate(const float* high, const float* low, const float* close,
     if (period <= 0 || period > size) {
         throw std::invalid_argument("ADX: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     adxKernel<<<grid, block, 0, stream>>>(high, low, close, output, period, size);

--- a/src/indicators/ADXR.cu
+++ b/src/indicators/ADXR.cu
@@ -26,7 +26,7 @@ void ADXR::calculate(const float* high, const float* low, const float* close,
     ADX adxInd(period);
     adxInd.calculate(high, low, close, adx.get(), size, stream);
 
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     adxrKernel<<<grid, block, 0, stream>>>(adx.get(), output, period, size);

--- a/src/indicators/APO.cu
+++ b/src/indicators/APO.cu
@@ -39,7 +39,7 @@ void APO::calculate(const float* input, float* output, int size, cudaStream_t st
     if (fastPeriod >= slowPeriod) {
         throw std::invalid_argument("APO: fastPeriod must be < slowPeriod");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     apoKernel<<<grid, block, 0, stream>>>(input, output, fastPeriod, slowPeriod, size);

--- a/src/indicators/ATR.cu
+++ b/src/indicators/ATR.cu
@@ -48,7 +48,7 @@ void ATR::calculate(const float* high, const float* low, const float* close,
     if (period <= 0 || period > size) {
         throw std::invalid_argument("ATR: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     atrKernel<<<1, 1, 0, stream>>>(high, low, close, output, period, initial, size);
     CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/AbandonedBaby.cu
+++ b/src/indicators/AbandonedBaby.cu
@@ -19,7 +19,7 @@ __global__ void abandonedBabyKernel(const float* __restrict__ open,
 
 void AbandonedBaby::calculate(const float* open, const float* high, const float* low,
                               const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     abandonedBabyKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/AdvanceBlock.cu
+++ b/src/indicators/AdvanceBlock.cu
@@ -19,7 +19,7 @@ __global__ void advanceBlockKernel(const float* __restrict__ open,
 
 void AdvanceBlock::calculate(const float* open, const float* high, const float* low,
                              const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     advanceBlockKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Aroon.cu
+++ b/src/indicators/Aroon.cu
@@ -56,7 +56,7 @@ void Aroon::calculate(const float* high, const float* low, float* output, int si
     if (upPeriod <= 0 || upPeriod > size || downPeriod <= 0 || downPeriod > size) {
         throw std::invalid_argument("Aroon: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, 3 * size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 3 * size * sizeof(float), stream));
     aroonKernel<<<1, 1, 0, stream>>>(high, low, output, upPeriod, downPeriod, size);
     CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/AroonOscillator.cu
+++ b/src/indicators/AroonOscillator.cu
@@ -41,7 +41,7 @@ void AroonOscillator::calculate(const float* high, const float* low,
     if (period <= 0 || period > size) {
         throw std::invalid_argument("AroonOscillator: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     aroonOscKernel<<<1, 1, 0, stream>>>(high, low, output, period, size);
     CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/BBANDS.cu
+++ b/src/indicators/BBANDS.cu
@@ -47,7 +47,7 @@ void BBANDS::calculate(const float* input, float* output, int size, cudaStream_t
         throw std::invalid_argument("BBANDS: invalid period");
     }
     // Initialize outputs with NaNs so unwritten tail retains NaN semantics
-    CUDA_CHECK(cudaMemset(output, 0xFF, 3 * size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 3 * size * sizeof(float), stream));
 
     auto prefix = acquireDeviceBuffer<float>(size);
     auto squared = acquireDeviceBuffer<float>(size);

--- a/src/indicators/BOP.cu
+++ b/src/indicators/BOP.cu
@@ -17,7 +17,7 @@ __global__ void bopKernel(const float* __restrict__ open,
 
 void BOP::calculate(const float* open, const float* high, const float* low,
                     const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     bopKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/BearishEngulfing.cu
+++ b/src/indicators/BearishEngulfing.cu
@@ -17,7 +17,7 @@ __global__ void bearishEngulfingKernel(const float* __restrict__ open,
 
 void BearishEngulfing::calculate(const float* open, const float* high, const float* low,
                                  const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     bearishEngulfingKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/BeltHold.cu
+++ b/src/indicators/BeltHold.cu
@@ -16,7 +16,7 @@ __global__ void beltHoldKernel(const float* __restrict__ open,
 
 void BeltHold::calculate(const float* open, const float* high, const float* low,
                          const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     beltHoldKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Beta.cu
+++ b/src/indicators/Beta.cu
@@ -33,7 +33,7 @@ void Beta::calculate(const float* x, const float* y, float* output, int size, cu
     if (period <= 0 || period > size) {
         throw std::invalid_argument("Beta: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     betaKernel<<<grid, block, 0, stream>>>(x, y, output, period, size);

--- a/src/indicators/Breakaway.cu
+++ b/src/indicators/Breakaway.cu
@@ -21,7 +21,7 @@ __global__ void breakawayKernel(const float* __restrict__ open,
 
 void Breakaway::calculate(const float* open, const float* high, const float* low,
                           const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     breakawayKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/BullishEngulfing.cu
+++ b/src/indicators/BullishEngulfing.cu
@@ -17,7 +17,7 @@ __global__ void bullishEngulfingKernel(const float* __restrict__ open,
 
 void BullishEngulfing::calculate(const float* open, const float* high, const float* low,
                                  const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     bullishEngulfingKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/CCI.cu
+++ b/src/indicators/CCI.cu
@@ -35,7 +35,7 @@ void CCI::calculate(const float* high, const float* low, const float* close,
     if (period <= 0 || period > size) {
         throw std::invalid_argument("CCI: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     cciKernel<<<grid, block, 0, stream>>>(high, low, close, output, period, size);

--- a/src/indicators/CMO.cu
+++ b/src/indicators/CMO.cu
@@ -27,7 +27,7 @@ void CMO::calculate(const float* input, float* output, int size, cudaStream_t st
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("CMO: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     cmoKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/Change.cu
+++ b/src/indicators/Change.cu
@@ -16,7 +16,7 @@ void Change::calculate(const float* input, float* output, int size, cudaStream_t
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("Change: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     changeKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/ClosingMarubozu.cu
+++ b/src/indicators/ClosingMarubozu.cu
@@ -18,7 +18,7 @@ __global__ void closingMarubozuKernel(const float *__restrict__ open,
 void ClosingMarubozu::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   closingMarubozuKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ConcealBabySwallow.cu
+++ b/src/indicators/ConcealBabySwallow.cu
@@ -23,7 +23,7 @@ __global__ void concealBabySwallowKernel(const float *__restrict__ open,
 void ConcealBabySwallow::calculate(const float *open, const float *high,
                                    const float *low, const float *close,
                                    float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   concealBabySwallowKernel<<<grid, block, 0, stream>>>(open, high, low, close, output,

--- a/src/indicators/Correl.cu
+++ b/src/indicators/Correl.cu
@@ -35,7 +35,7 @@ void Correl::calculate(const float* x, const float* y, float* output, int size, 
     if (period <= 0 || period > size) {
         throw std::invalid_argument("Correl: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     correlKernel<<<grid, block, 0, stream>>>(x, y, output, period, size);

--- a/src/indicators/CounterAttack.cu
+++ b/src/indicators/CounterAttack.cu
@@ -20,7 +20,7 @@ __global__ void counterAttackKernel(const float *__restrict__ open,
 void CounterAttack::calculate(const float *open, const float *high,
                               const float *low, const float *close,
                               float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   counterAttackKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/DEMA.cu
+++ b/src/indicators/DEMA.cu
@@ -22,7 +22,7 @@ void DEMA::calculate(const float* input, float* output, int size, cudaStream_t s
         throw std::invalid_argument("DEMA: invalid period");
     }
 
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     auto ema1 = acquireDeviceBuffer<float>(size);
     auto ema2 = acquireDeviceBuffer<float>(size);

--- a/src/indicators/DX.cu
+++ b/src/indicators/DX.cu
@@ -45,7 +45,7 @@ void DX::calculate(const float* high, const float* low, const float* close,
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("DX: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     dxKernel<<<grid, block, 0, stream>>>(high, low, close, output, period, size);

--- a/src/indicators/DarkCloudCover.cu
+++ b/src/indicators/DarkCloudCover.cu
@@ -20,7 +20,7 @@ __global__ void darkCloudCoverKernel(const float *__restrict__ open,
 void DarkCloudCover::calculate(const float *open, const float *high,
                                const float *low, const float *close,
                                float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   darkCloudCoverKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Doji.cu
+++ b/src/indicators/Doji.cu
@@ -18,7 +18,7 @@ Doji::Doji(float threshold) : threshold(threshold) {}
 
 void Doji::calculate(const float* open, const float* high, const float* low,
                      const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     dojiKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size, threshold);

--- a/src/indicators/DojiStar.cu
+++ b/src/indicators/DojiStar.cu
@@ -20,7 +20,7 @@ __global__ void dojiStarKernel(const float *__restrict__ open,
 void DojiStar::calculate(const float *open, const float *high, const float *low,
                          const float *close, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   dojiStarKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/DragonflyDoji.cu
+++ b/src/indicators/DragonflyDoji.cu
@@ -18,7 +18,7 @@ __global__ void dragonflyDojiKernel(const float *__restrict__ open,
 void DragonflyDoji::calculate(const float *open, const float *high,
                               const float *low, const float *close,
                               float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   dragonflyDojiKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/EMA.cu
+++ b/src/indicators/EMA.cu
@@ -27,7 +27,7 @@ void EMA::calculate(const float* input, float* output, int size, cudaStream_t st
         throw std::invalid_argument("EMA: invalid period");
     }
     // Initialize output with NaNs so unwritten tail remains NaN
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);

--- a/src/indicators/Engulfing.cu
+++ b/src/indicators/Engulfing.cu
@@ -17,7 +17,7 @@ __global__ void engulfingKernel(const float *__restrict__ open,
 void Engulfing::calculate(const float *open, const float *high,
                           const float *low, const float *close, float *output,
                           int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   engulfingKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/EveningDojiStar.cu
+++ b/src/indicators/EveningDojiStar.cu
@@ -22,7 +22,7 @@ __global__ void eveningDojiStarKernel(const float *__restrict__ open,
 void EveningDojiStar::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   eveningDojiStarKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/EveningStar.cu
+++ b/src/indicators/EveningStar.cu
@@ -21,7 +21,7 @@ __global__ void eveningStarKernel(const float *__restrict__ open,
 void EveningStar::calculate(const float *open, const float *high,
                             const float *low, const float *close, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   eveningStarKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/GapSideSideWhite.cu
+++ b/src/indicators/GapSideSideWhite.cu
@@ -20,7 +20,7 @@ __global__ void gapSideSideWhiteKernel(const float* __restrict__ open,
 void GapSideSideWhite::calculate(const float* open, const float* high,
                                  const float* low, const float* close,
                                  float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     gapSideSideWhiteKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/GravestoneDoji.cu
+++ b/src/indicators/GravestoneDoji.cu
@@ -19,7 +19,7 @@ __global__ void gravestoneDojiKernel(const float* __restrict__ open,
 void GravestoneDoji::calculate(const float* open, const float* high,
                                const float* low, const float* close,
                                float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     gravestoneDojiKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Hammer.cu
+++ b/src/indicators/Hammer.cu
@@ -16,7 +16,7 @@ __global__ void hammerKernel(const float* __restrict__ open,
 
 void Hammer::calculate(const float* open, const float* high, const float* low,
                        const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     hammerKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/HangingMan.cu
+++ b/src/indicators/HangingMan.cu
@@ -19,7 +19,7 @@ __global__ void hangingManKernel(const float* __restrict__ open,
 void HangingMan::calculate(const float* open, const float* high,
                            const float* low, const float* close,
                            float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     hangingManKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Harami.cu
+++ b/src/indicators/Harami.cu
@@ -17,7 +17,7 @@ __global__ void haramiKernel(const float* __restrict__ open,
 void Harami::calculate(const float* open, const float* high,
                        const float* low, const float* close,
                        float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     haramiKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/HaramiCross.cu
+++ b/src/indicators/HaramiCross.cu
@@ -19,7 +19,7 @@ __global__ void haramiCrossKernel(const float* __restrict__ open,
 void HaramiCross::calculate(const float* open, const float* high,
                             const float* low, const float* close,
                             float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     haramiCrossKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/HighWave.cu
+++ b/src/indicators/HighWave.cu
@@ -17,7 +17,7 @@ __global__ void highWaveKernel(const float* __restrict__ open,
 void HighWave::calculate(const float* open, const float* high,
                          const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     highWaveKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Hikkake.cu
+++ b/src/indicators/Hikkake.cu
@@ -19,7 +19,7 @@ __global__ void hikkakeKernel(const float* __restrict__ open,
 void Hikkake::calculate(const float* open, const float* high, const float* low,
                         const float* close, float* output,
                         int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     hikkakeKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/HikkakeMod.cu
+++ b/src/indicators/HikkakeMod.cu
@@ -22,7 +22,7 @@ __global__ void hikkakeModKernel(const float* __restrict__ open,
 void HikkakeMod::calculate(const float* open, const float* high,
                            const float* low, const float* close,
                            float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     hikkakeModKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/HomingPigeon.cu
+++ b/src/indicators/HomingPigeon.cu
@@ -20,7 +20,7 @@ __global__ void homingPigeonKernel(const float* __restrict__ open,
 void HomingPigeon::calculate(const float* open, const float* high,
                              const float* low, const float* close,
                              float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     homingPigeonKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/IdenticalThreeCrows.cu
+++ b/src/indicators/IdenticalThreeCrows.cu
@@ -23,7 +23,7 @@ __global__ void identicalThreeCrowsKernel(const float *__restrict__ open,
 void IdenticalThreeCrows::calculate(const float *open, const float *high,
                                     const float *low, const float *close,
                                     float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   identicalThreeCrowsKernel<<<grid, block, 0, stream>>>(open, high, low, close, output,

--- a/src/indicators/InNeck.cu
+++ b/src/indicators/InNeck.cu
@@ -20,7 +20,7 @@ __global__ void inNeckKernel(const float *__restrict__ open,
 void InNeck::calculate(const float *open, const float *high, const float *low,
                        const float *close, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   inNeckKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/InvertedHammer.cu
+++ b/src/indicators/InvertedHammer.cu
@@ -16,7 +16,7 @@ __global__ void invertedHammerKernel(const float* __restrict__ open,
 
 void InvertedHammer::calculate(const float* open, const float* high, const float* low,
                                const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     invertedHammerKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/KAMA.cu
+++ b/src/indicators/KAMA.cu
@@ -35,7 +35,7 @@ void KAMA::calculate(const float *input, float *output,
     throw std::invalid_argument("KAMA: invalid period");
   }
   // Initialize output with NaNs so unwritten tail remains NaN
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
   kamaKernel<<<1, 1, 0, stream>>>(input, output, period, fastSC, slowSC, size);
   CUDA_CHECK(cudaGetLastError());

--- a/src/indicators/Kicking.cu
+++ b/src/indicators/Kicking.cu
@@ -20,7 +20,7 @@ __global__ void kickingKernel(const float *__restrict__ open,
 void Kicking::calculate(const float *open, const float *high, const float *low,
                         const float *close, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   kickingKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/KickingByLength.cu
+++ b/src/indicators/KickingByLength.cu
@@ -20,7 +20,7 @@ __global__ void kickingByLengthKernel(const float *__restrict__ open,
 void KickingByLength::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   kickingByLengthKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/LINEARREG.cu
+++ b/src/indicators/LINEARREG.cu
@@ -29,7 +29,7 @@ void LINEARREG::calculate(const float* input, float* output, int size, cudaStrea
     if (period <= 0 || period > size) {
         throw std::invalid_argument("LINEARREG: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     linearregKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/LINEARREG_ANGLE.cu
+++ b/src/indicators/LINEARREG_ANGLE.cu
@@ -29,7 +29,7 @@ void LINEARREG_ANGLE::calculate(const float* input, float* output, int size, cud
     if (period <= 0 || period > size) {
         throw std::invalid_argument("LINEARREG_ANGLE: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     linearregAngleKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/LINEARREG_INTERCEPT.cu
+++ b/src/indicators/LINEARREG_INTERCEPT.cu
@@ -29,7 +29,7 @@ void LINEARREG_INTERCEPT::calculate(const float* input, float* output, int size,
     if (period <= 0 || period > size) {
         throw std::invalid_argument("LINEARREG_INTERCEPT: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     linearregInterceptKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/LINEARREG_SLOPE.cu
+++ b/src/indicators/LINEARREG_SLOPE.cu
@@ -28,7 +28,7 @@ void LINEARREG_SLOPE::calculate(const float* input, float* output, int size, cud
     if (period <= 0 || period > size) {
         throw std::invalid_argument("LINEARREG_SLOPE: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     linearregSlopeKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/LadderBottom.cu
+++ b/src/indicators/LadderBottom.cu
@@ -23,7 +23,7 @@ __global__ void ladderBottomKernel(const float* __restrict__ open,
 void LadderBottom::calculate(const float* open, const float* high,
                              const float* low, const float* close,
                              float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     ladderBottomKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/LongLeggedDoji.cu
+++ b/src/indicators/LongLeggedDoji.cu
@@ -18,7 +18,7 @@ __global__ void longLeggedDojiKernel(const float* __restrict__ open,
 void LongLeggedDoji::calculate(const float* open, const float* high,
                                const float* low, const float* close,
                                float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     longLeggedDojiKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/LongLine.cu
+++ b/src/indicators/LongLine.cu
@@ -17,7 +17,7 @@ __global__ void longLineKernel(const float* __restrict__ open,
 void LongLine::calculate(const float* open, const float* high,
                          const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     longLineKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/MACD.cu
+++ b/src/indicators/MACD.cu
@@ -81,7 +81,7 @@ void MACD::calculate(const float* input, float* output, int size, cudaStream_t s
     // Warm-up region at the beginning should remain NaN. Initialize the
     // entire output with NaNs and only compute values for indices beyond the
     // slowPeriod.
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     auto emaFast = acquireDeviceBuffer<float>(size);
     auto emaSlow = acquireDeviceBuffer<float>(size);

--- a/src/indicators/MACDEXT.cu
+++ b/src/indicators/MACDEXT.cu
@@ -111,7 +111,7 @@ void MACDEXT::calculate(const float* input, float* output, int size, cudaStream_
     if (fastPeriod >= slowPeriod) {
         throw std::invalid_argument("MACD: fastPeriod must be < slowPeriod");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, 3 * size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 3 * size * sizeof(float), stream));
     float* macd = output;
     float* signal = output + size;
     float* hist = output + 2 * size;

--- a/src/indicators/MAMA.cu
+++ b/src/indicators/MAMA.cu
@@ -29,7 +29,7 @@ void MAMA::calculate(const float* input, float* output, int size, cudaStream_t s
     if (size <= 0) {
         throw std::invalid_argument("MAMA: invalid size");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, 2 * size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 2 * size * sizeof(float), stream));
     float* mama = output;
     float* fama = output + size;
     mamaKernel<<<1, 1, 0, stream>>>(input, mama, fama, fastLimit, slowLimit, size);

--- a/src/indicators/MAX.cu
+++ b/src/indicators/MAX.cu
@@ -21,7 +21,7 @@ void MAX::calculate(const float* input, float* output, int size, cudaStream_t st
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MAX: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     maxKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/MAXINDEX.cu
+++ b/src/indicators/MAXINDEX.cu
@@ -27,7 +27,7 @@ void MAXINDEX::calculate(const float* input, float* output, int size, cudaStream
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MAXINDEX: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     maxIndexKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/MFI.cu
+++ b/src/indicators/MFI.cu
@@ -57,7 +57,7 @@ void MFI::calculate(const float* high, const float* low, const float* close,
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MFI: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     auto signedMF = acquireDeviceBuffer<float>(size);
     mfiKernel<<<1, 1, 0, stream>>>(high, low, close, volume, signedMF.get(), output, period, size);
     CUDA_CHECK(cudaGetLastError());

--- a/src/indicators/MIDPOINT.cu
+++ b/src/indicators/MIDPOINT.cu
@@ -25,7 +25,7 @@ void MIDPOINT::calculate(const float* input, float* output, int size, cudaStream
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MIDPOINT: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     midpointKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/MIDPRICE.cu
+++ b/src/indicators/MIDPRICE.cu
@@ -25,7 +25,7 @@ void MIDPRICE::calculate(const float* high, const float* low, float* output, int
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MIDPRICE: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     midpriceKernel<<<grid, block, 0, stream>>>(high, low, output, period, size);

--- a/src/indicators/MIN.cu
+++ b/src/indicators/MIN.cu
@@ -21,7 +21,7 @@ void MIN::calculate(const float* input, float* output, int size, cudaStream_t st
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MIN: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     minKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/MININDEX.cu
+++ b/src/indicators/MININDEX.cu
@@ -28,7 +28,7 @@ void MININDEX::calculate(const float *input, float *output,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MININDEX: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   minIndexKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/MINMAX.cu
+++ b/src/indicators/MINMAX.cu
@@ -27,7 +27,7 @@ void MINMAX::calculate(const float *input, float *output,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MINMAX: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, 2 * size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 2 * size * sizeof(float), stream));
   float *minOut = output;
   float *maxOut = output + size;
   dim3 block = defaultBlock();

--- a/src/indicators/MINMAXINDEX.cu
+++ b/src/indicators/MINMAXINDEX.cu
@@ -36,7 +36,7 @@ void MINMAXINDEX::calculate(const float *input, float *output,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MINMAXINDEX: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, 2 * size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 2 * size * sizeof(float), stream));
   float *minOut = output;
   float *maxOut = output + size;
   dim3 block = defaultBlock();

--- a/src/indicators/Marubozu.cu
+++ b/src/indicators/Marubozu.cu
@@ -17,7 +17,7 @@ __global__ void marubozuKernel(const float* __restrict__ open,
 void Marubozu::calculate(const float* open, const float* high,
                          const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     marubozuKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/MatHold.cu
+++ b/src/indicators/MatHold.cu
@@ -23,7 +23,7 @@ __global__ void matHoldKernel(const float *__restrict__ open,
 void MatHold::calculate(const float *open, const float *high, const float *low,
                         const float *close, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   matHoldKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/MatchingLow.cu
+++ b/src/indicators/MatchingLow.cu
@@ -20,7 +20,7 @@ __global__ void matchingLowKernel(const float* __restrict__ open,
 void MatchingLow::calculate(const float* open, const float* high,
                              const float* low, const float* close,
                              float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     matchingLowKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/MinusDI.cu
+++ b/src/indicators/MinusDI.cu
@@ -44,7 +44,7 @@ void MinusDI::calculate(const float *high, const float *low, const float *close,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MinusDI: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   minusDIKernel<<<1, 1, 0, stream>>>(high, low, close, output, period, size);
   CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/MinusDM.cu
+++ b/src/indicators/MinusDM.cu
@@ -41,7 +41,7 @@ void MinusDM::calculate(const float *high, const float *low, float *output,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MinusDM: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   minusDMKernel<<<1, 1, 0, stream>>>(high, low, output, period, size);
   CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/Momentum.cu
+++ b/src/indicators/Momentum.cu
@@ -18,7 +18,7 @@ void Momentum::calculate(const float* input, float* output, int size, cudaStream
     }
     // Pre-fill the output buffer with NaNs so that the unwritten tail
     // represents the warm-up region.
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);

--- a/src/indicators/MorningDojiStar.cu
+++ b/src/indicators/MorningDojiStar.cu
@@ -22,7 +22,7 @@ __global__ void morningDojiStarKernel(const float *__restrict__ open,
 void MorningDojiStar::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   morningDojiStarKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/MorningStar.cu
+++ b/src/indicators/MorningStar.cu
@@ -21,7 +21,7 @@ __global__ void morningStarKernel(const float *__restrict__ open,
 void MorningStar::calculate(const float *open, const float *high,
                             const float *low, const float *close, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   morningStarKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/NATR.cu
+++ b/src/indicators/NATR.cu
@@ -39,7 +39,7 @@ void NATR::calculate(const float *high, const float *low, const float *close,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("NATR: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   natrKernel<<<1, 1, 0, stream>>>(high, low, close, output, period, size);
   CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/OnNeck.cu
+++ b/src/indicators/OnNeck.cu
@@ -20,7 +20,7 @@ __global__ void onNeckKernel(const float *__restrict__ open,
 void OnNeck::calculate(const float *open, const float *high, const float *low,
                        const float *close, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   onNeckKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/PPO.cu
+++ b/src/indicators/PPO.cu
@@ -40,7 +40,7 @@ void PPO::calculate(const float* input, float* output,
   if (fastPeriod >= slowPeriod) {
     throw std::invalid_argument("PPO: fastPeriod must be < slowPeriod");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   ppoKernel<<<grid, block, 0, stream>>>(input, output, fastPeriod, slowPeriod, size);

--- a/src/indicators/PVO.cu
+++ b/src/indicators/PVO.cu
@@ -40,7 +40,7 @@ void PVO::calculate(const float* input, float* output,
   if (fastPeriod >= slowPeriod) {
     throw std::invalid_argument("PVO: fastPeriod must be < slowPeriod");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   pvoKernel<<<grid, block, 0, stream>>>(input, output, fastPeriod, slowPeriod, size);

--- a/src/indicators/Piercing.cu
+++ b/src/indicators/Piercing.cu
@@ -20,7 +20,7 @@ __global__ void piercingKernel(const float *__restrict__ open,
 void Piercing::calculate(const float *open, const float *high, const float *low,
                          const float *close, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   piercingKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/PlusDI.cu
+++ b/src/indicators/PlusDI.cu
@@ -43,7 +43,7 @@ void PlusDI::calculate(const float *high, const float *low, const float *close,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("PlusDI: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   plusDIKernel<<<1, 1, 0, stream>>>(high, low, close, output, period, size);
   CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/PlusDM.cu
+++ b/src/indicators/PlusDM.cu
@@ -40,7 +40,7 @@ void PlusDM::calculate(const float *high, const float *low, float *output,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("PlusDM: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   plusDMKernel<<<1, 1, 0, stream>>>(high, low, output, period, size);
   CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/ROC.cu
+++ b/src/indicators/ROC.cu
@@ -18,7 +18,7 @@ void ROC::calculate(const float* input, float* output, int size, cudaStream_t st
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("ROC: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     rocKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/ROCP.cu
+++ b/src/indicators/ROCP.cu
@@ -19,7 +19,7 @@ void ROCP::calculate(const float *input, float *output,
   if (period <= 0 || period >= size) {
     throw std::invalid_argument("ROCP: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   rocpKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/ROCR.cu
+++ b/src/indicators/ROCR.cu
@@ -19,7 +19,7 @@ void ROCR::calculate(const float *input, float *output,
   if (period <= 0 || period >= size) {
     throw std::invalid_argument("ROCR: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   rocrKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/ROCR100.cu
+++ b/src/indicators/ROCR100.cu
@@ -20,7 +20,7 @@ void ROCR100::calculate(const float *input, float *output,
   if (period <= 0 || period >= size) {
     throw std::invalid_argument("ROCR100: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   rocr100Kernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/RSI.cu
+++ b/src/indicators/RSI.cu
@@ -47,7 +47,7 @@ void RSI::calculate(const float* input, float* output, int size, cudaStream_t st
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("RSI: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     auto gain = acquireDeviceBuffer<float>(size);
     auto loss = acquireDeviceBuffer<float>(size);

--- a/src/indicators/RickshawMan.cu
+++ b/src/indicators/RickshawMan.cu
@@ -18,7 +18,7 @@ __global__ void rickshawManKernel(const float *__restrict__ open,
 void RickshawMan::calculate(const float *open, const float *high,
                             const float *low, const float *close, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   rickshawManKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/RiseFall3Methods.cu
+++ b/src/indicators/RiseFall3Methods.cu
@@ -21,7 +21,7 @@ __global__ void riseFall3MethodsKernel(const float *__restrict__ open,
 void RiseFall3Methods::calculate(const float *open, const float *high,
                                  const float *low, const float *close,
                                  float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   riseFall3MethodsKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/SAR.cu
+++ b/src/indicators/SAR.cu
@@ -59,7 +59,7 @@ void SAR::calculate(const float* high, const float* low,
     if (size <= 0) {
         throw std::invalid_argument("SAR: invalid size");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     sarKernel<<<1, 1, 0, stream>>>(high, low, output, step, maxAcceleration, size);
     CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/SAREXT.cu
+++ b/src/indicators/SAREXT.cu
@@ -64,7 +64,7 @@ void SAREXT::calculate(const float* high, const float* low,
     if (size <= 0) {
         throw std::invalid_argument("SAREXT: invalid size");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     sarextKernel<<<1, 1, 0, stream>>>(high, low, output, startValue, offsetOnReverse,
                           accInitLong, accLong, accMaxLong,
                           accInitShort, accShort, accMaxShort, size);

--- a/src/indicators/SMA.cu
+++ b/src/indicators/SMA.cu
@@ -24,7 +24,7 @@ void SMA::calculate(const float* input, float* output, int size, cudaStream_t st
     }
     // Initialize the entire output array with NaNs so that any unwritten
     // warm-up region retains the expected NaN semantics.
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     // Compute prefix sums of the input using Thrust.
     auto prefix = acquireDeviceBuffer<float>(size);

--- a/src/indicators/SUM.cu
+++ b/src/indicators/SUM.cu
@@ -22,7 +22,7 @@ void SUM::calculate(const float *input, float *output,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("SUM: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
   auto prefix = acquireDeviceBuffer<float>(size);
   thrust::device_ptr<const float> inPtr(input);

--- a/src/indicators/SeparatingLines.cu
+++ b/src/indicators/SeparatingLines.cu
@@ -18,7 +18,7 @@ __global__ void separatingLinesKernel(const float *__restrict__ open,
 void SeparatingLines::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   separatingLinesKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ShootingStar.cu
+++ b/src/indicators/ShootingStar.cu
@@ -18,7 +18,7 @@ __global__ void shootingStarKernel(const float *__restrict__ open,
 void ShootingStar::calculate(const float *open, const float *high,
                              const float *low, const float *close,
                              float *output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   shootingStarKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ShortLine.cu
+++ b/src/indicators/ShortLine.cu
@@ -17,7 +17,7 @@ __global__ void shortLineKernel(const float *__restrict__ open,
 void ShortLine::calculate(const float *open, const float *high,
                           const float *low, const float *close, float *output,
                           int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   shortLineKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/SpinningTop.cu
+++ b/src/indicators/SpinningTop.cu
@@ -17,7 +17,7 @@ __global__ void spinningTopKernel(const float* __restrict__ open,
 void SpinningTop::calculate(const float* open, const float* high,
                             const float* low, const float* close,
                             float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     spinningTopKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/StalledPattern.cu
+++ b/src/indicators/StalledPattern.cu
@@ -21,7 +21,7 @@ __global__ void stalledPatternKernel(const float* __restrict__ open,
 void StalledPattern::calculate(const float* open, const float* high,
                                const float* low, const float* close,
                                float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     stalledPatternKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/StdDev.cu
+++ b/src/indicators/StdDev.cu
@@ -26,7 +26,7 @@ void StdDev::calculate(const float* input, float* output, int size, cudaStream_t
     if (period <= 0 || period > size) {
         throw std::invalid_argument("StdDev: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     stddevKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/StickSandwich.cu
+++ b/src/indicators/StickSandwich.cu
@@ -21,7 +21,7 @@ __global__ void stickSandwichKernel(const float* __restrict__ open,
 void StickSandwich::calculate(const float* open, const float* high,
                               const float* low, const float* close,
                               float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     stickSandwichKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Stochastic.cu
+++ b/src/indicators/Stochastic.cu
@@ -49,7 +49,7 @@ void Stochastic::calculate(const float* high, const float* low, const float* clo
     if (kPeriod <= 0 || dPeriod <= 0 || kPeriod + dPeriod - 1 > size) {
         throw std::invalid_argument("Stochastic: invalid periods");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, 2 * size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 2 * size * sizeof(float), stream));
     float* kOut = output;
     float* dOut = output + size;
     stochasticKernel<<<1, 1, 0, stream>>>(high, low, close, kOut, dOut, kPeriod, dPeriod, size);

--- a/src/indicators/StochasticFast.cu
+++ b/src/indicators/StochasticFast.cu
@@ -45,7 +45,7 @@ void StochasticFast::calculate(const float* high, const float* low, const float*
     if (kPeriod <= 0 || dPeriod <= 0 || kPeriod > size) {
         throw std::invalid_argument("StochasticFast: invalid periods");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, 2 * size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 2 * size * sizeof(float), stream));
     float* kOut = output;
     float* dOut = output + size;
     stochfKernel<<<1, 1, 0, stream>>>(high, low, close, kOut, dOut, kPeriod, dPeriod, size);

--- a/src/indicators/T3.cu
+++ b/src/indicators/T3.cu
@@ -25,7 +25,7 @@ void T3::calculate(const float *input, float *output,
   if (period <= 0 || size < 3 * period - 2) {
     throw std::invalid_argument("T3: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
   auto e1 = acquireDeviceBuffer<float>(size);
   auto e2 = acquireDeviceBuffer<float>(size);

--- a/src/indicators/TEMA.cu
+++ b/src/indicators/TEMA.cu
@@ -25,7 +25,7 @@ void TEMA::calculate(const float* input, float* output, int size, cudaStream_t s
         throw std::invalid_argument("TEMA: invalid period");
     }
 
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     auto ema1 = acquireDeviceBuffer<float>(size);
     auto ema2 = acquireDeviceBuffer<float>(size);

--- a/src/indicators/TRIMA.cu
+++ b/src/indicators/TRIMA.cu
@@ -11,7 +11,7 @@ void TRIMA::calculate(const float *input, float *output,
   if (period <= 0 || size < period) {
     throw std::invalid_argument("TRIMA: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   int p1 = (period + 1) / 2;
   int p2 = (period % 2 == 0) ? (p1 + 1) : p1;
 

--- a/src/indicators/TRIX.cu
+++ b/src/indicators/TRIX.cu
@@ -22,7 +22,7 @@ void TRIX::calculate(const float* input, float* output, int size, cudaStream_t s
         throw std::invalid_argument("TRIX: invalid period");
     }
 
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     auto ema1 = acquireDeviceBuffer<float>(size);
     auto ema2 = acquireDeviceBuffer<float>(size);

--- a/src/indicators/TSF.cu
+++ b/src/indicators/TSF.cu
@@ -29,7 +29,7 @@ void TSF::calculate(const float* input, float* output, int size, cudaStream_t st
     if (period <= 0 || period > size) {
         throw std::invalid_argument("TSF: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     tsfKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/Takuri.cu
+++ b/src/indicators/Takuri.cu
@@ -17,7 +17,7 @@ __global__ void takuriKernel(const float* __restrict__ open,
 void Takuri::calculate(const float* open, const float* high, const float* low,
                        const float* close, float* output,
                        int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     takuriKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/TasukiGap.cu
+++ b/src/indicators/TasukiGap.cu
@@ -20,7 +20,7 @@ __global__ void tasukiGapKernel(const float* __restrict__ open,
 void TasukiGap::calculate(const float* open, const float* high,
                           const float* low, const float* close,
                           float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     tasukiGapKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ThreeBlackCrows.cu
+++ b/src/indicators/ThreeBlackCrows.cu
@@ -19,7 +19,7 @@ __global__ void threeBlackCrowsKernel(const float* __restrict__ open,
 
 void ThreeBlackCrows::calculate(const float* open, const float* high, const float* low,
                                 const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     threeBlackCrowsKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ThreeInside.cu
+++ b/src/indicators/ThreeInside.cu
@@ -19,7 +19,7 @@ __global__ void threeInsideKernel(const float* __restrict__ open,
 
 void ThreeInside::calculate(const float* open, const float* high, const float* low,
                             const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     threeInsideKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ThreeLineStrike.cu
+++ b/src/indicators/ThreeLineStrike.cu
@@ -20,7 +20,7 @@ __global__ void threeLineStrikeKernel(const float* __restrict__ open,
 
 void ThreeLineStrike::calculate(const float* open, const float* high, const float* low,
                                 const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     threeLineStrikeKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ThreeStarsInSouth.cu
+++ b/src/indicators/ThreeStarsInSouth.cu
@@ -19,7 +19,7 @@ __global__ void threeStarsInSouthKernel(const float* __restrict__ open,
 
 void ThreeStarsInSouth::calculate(const float* open, const float* high, const float* low,
                                   const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     threeStarsInSouthKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ThreeWhiteSoldiers.cu
+++ b/src/indicators/ThreeWhiteSoldiers.cu
@@ -19,7 +19,7 @@ __global__ void threeWhiteSoldiersKernel(const float* __restrict__ open,
 
 void ThreeWhiteSoldiers::calculate(const float* open, const float* high, const float* low,
                                    const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     threeWhiteSoldiersKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Thrusting.cu
+++ b/src/indicators/Thrusting.cu
@@ -20,7 +20,7 @@ __global__ void thrustingKernel(const float* __restrict__ open,
 void Thrusting::calculate(const float* open, const float* high,
                           const float* low, const float* close,
                           float* output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   thrustingKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/Tristar.cu
+++ b/src/indicators/Tristar.cu
@@ -19,7 +19,7 @@ __global__ void tristarKernel(const float* __restrict__ open,
 void Tristar::calculate(const float* open, const float* high,
                          const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   tristarKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/TwoCrows.cu
+++ b/src/indicators/TwoCrows.cu
@@ -19,7 +19,7 @@ __global__ void twoCrowsKernel(const float* __restrict__ open,
 
 void TwoCrows::calculate(const float* open, const float* high, const float* low,
                          const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     twoCrowsKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/ULTOSC.cu
+++ b/src/indicators/ULTOSC.cu
@@ -39,7 +39,7 @@ void ULTOSC::calculate(const float* high, const float* low, const float* close,
         longPeriod >= size) {
         throw std::invalid_argument("ULTOSC: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     ultoscKernel<<<grid, block, 0, stream>>>(high, low, close, output,

--- a/src/indicators/Unique3River.cu
+++ b/src/indicators/Unique3River.cu
@@ -22,7 +22,7 @@ __global__ void unique3RiverKernel(const float* __restrict__ open,
 void Unique3River::calculate(const float* open, const float* high,
                               const float* low, const float* close,
                               float* output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   unique3RiverKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/UpsideGap2Crows.cu
+++ b/src/indicators/UpsideGap2Crows.cu
@@ -22,7 +22,7 @@ __global__ void upsideGap2CrowsKernel(const float* __restrict__ open,
 void UpsideGap2Crows::calculate(const float* open, const float* high,
                                 const float* low, const float* close,
                                 float* output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   upsideGap2CrowsKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);

--- a/src/indicators/VAR.cu
+++ b/src/indicators/VAR.cu
@@ -26,7 +26,7 @@ void VAR::calculate(const float* input, float* output, int size, cudaStream_t st
     if (period <= 0 || period > size) {
         throw std::invalid_argument("VAR: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);
     varKernel<<<grid, block, 0, stream>>>(input, output, period, size);

--- a/src/indicators/WILLR.cu
+++ b/src/indicators/WILLR.cu
@@ -33,7 +33,7 @@ void WILLR::calculate(const float *high, const float *low, const float *close,
   if (period <= 0 || period > size) {
     throw std::invalid_argument("WILLR: invalid period");
   }
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   willrKernel<<<1, 1, 0, stream>>>(high, low, close, output, period, size);
   CUDA_CHECK(cudaGetLastError());
 }

--- a/src/indicators/WMA.cu
+++ b/src/indicators/WMA.cu
@@ -22,7 +22,7 @@ void WMA::calculate(const float* input, float* output, int size, cudaStream_t st
     if (period <= 0 || period > size) {
         throw std::invalid_argument("WMA: invalid period");
     }
-    CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
 
     dim3 block = defaultBlock();
     dim3 grid = defaultGrid(size);

--- a/src/indicators/XSideGap3Methods.cu
+++ b/src/indicators/XSideGap3Methods.cu
@@ -20,7 +20,7 @@ __global__ void xSideGap3MethodsKernel(const float* __restrict__ open,
 void XSideGap3Methods::calculate(const float* open, const float* high,
                                  const float* low, const float* close,
                                  float* output, int size, cudaStream_t stream) noexcept(false) {
-  CUDA_CHECK(cudaMemset(output, 0xFF, size * sizeof(float)));
+  CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
   dim3 block = defaultBlock();
   dim3 grid = defaultGrid(size);
   xSideGap3MethodsKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);


### PR DESCRIPTION
## Summary
- replace synchronous cudaMemset calls in indicator calculations with cudaMemsetAsync(..., stream) so memory initialization obeys the provided CUDA stream

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release *(fails: nvcc not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c93e3ebca88329a8e3d9799f6bc53d