### PR TITLE
Wrap indicators in namespace

### DIFF
--- a/include/indicators/AD.h
+++ b/include/indicators/AD.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class AD : public Indicator {
 public:
     AD() = default;
@@ -10,5 +11,7 @@ public:
                    const float* volume, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ADOSC.h
+++ b/include/indicators/ADOSC.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ADOSC : public Indicator {
 public:
     ADOSC(int shortPeriod, int longPeriod);
@@ -13,5 +14,7 @@ private:
     int shortPeriod;
     int longPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ADX.h
+++ b/include/indicators/ADX.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ADX : public Indicator {
 public:
     explicit ADX(int period);
@@ -12,5 +13,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ADXR.h
+++ b/include/indicators/ADXR.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ADXR : public Indicator {
 public:
     explicit ADXR(int period);
@@ -12,5 +13,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/APO.h
+++ b/include/indicators/APO.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class APO : public Indicator {
 public:
     APO(int fastPeriod, int slowPeriod);
@@ -11,5 +12,7 @@ private:
     int fastPeriod;
     int slowPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ATR.h
+++ b/include/indicators/ATR.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ATR : public Indicator {
 public:
     explicit ATR(int period, float initial = 0.0f);
@@ -13,5 +14,7 @@ private:
     int period;
     float initial;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/AbandonedBaby.h
+++ b/include/indicators/AbandonedBaby.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class AbandonedBaby : public Indicator {
 public:
     AbandonedBaby() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/AdvanceBlock.h
+++ b/include/indicators/AdvanceBlock.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class AdvanceBlock : public Indicator {
 public:
     AdvanceBlock() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/Aroon.h
+++ b/include/indicators/Aroon.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Aroon : public Indicator {
 public:
     Aroon(int upPeriod, int downPeriod);
@@ -12,5 +13,7 @@ private:
     int upPeriod;
     int downPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/AroonOscillator.h
+++ b/include/indicators/AroonOscillator.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class AroonOscillator : public Indicator {
 public:
     explicit AroonOscillator(int period);
@@ -11,5 +12,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/AvgPrice.h
+++ b/include/indicators/AvgPrice.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class AvgPrice : public Indicator {
 public:
     AvgPrice() = default;
@@ -10,5 +11,7 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/BBANDS.h
+++ b/include/indicators/BBANDS.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class BBANDS : public Indicator {
 public:
     BBANDS(int period, float upperMultiplier, float lowerMultiplier);
@@ -12,5 +13,7 @@ private:
     float upperMultiplier;
     float lowerMultiplier;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/BOP.h
+++ b/include/indicators/BOP.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class BOP : public Indicator {
 public:
     BOP() = default;
@@ -10,5 +11,7 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/BearishEngulfing.h
+++ b/include/indicators/BearishEngulfing.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class BearishEngulfing : public Indicator {
 public:
     BearishEngulfing() = default;
@@ -10,5 +11,7 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/BeltHold.h
+++ b/include/indicators/BeltHold.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class BeltHold : public Indicator {
 public:
     BeltHold() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/Beta.h
+++ b/include/indicators/Beta.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Beta : public Indicator {
 public:
     explicit Beta(int period);
@@ -11,5 +12,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Breakaway.h
+++ b/include/indicators/Breakaway.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Breakaway : public Indicator {
 public:
     Breakaway() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/BullishEngulfing.h
+++ b/include/indicators/BullishEngulfing.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class BullishEngulfing : public Indicator {
 public:
     BullishEngulfing() = default;
@@ -10,5 +11,7 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/CCI.h
+++ b/include/indicators/CCI.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class CCI : public Indicator {
 public:
     explicit CCI(int period);
@@ -12,5 +13,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/CMO.h
+++ b/include/indicators/CMO.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class CMO : public Indicator {
 public:
     explicit CMO(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Change.h
+++ b/include/indicators/Change.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Change : public Indicator {
 public:
     explicit Change(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ClosingMarubozu.h
+++ b/include/indicators/ClosingMarubozu.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ClosingMarubozu : public Indicator {
 public:
   void calculate(const float *open, const float *high, const float *low,
@@ -10,5 +11,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ConcealBabySwallow.h
+++ b/include/indicators/ConcealBabySwallow.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ConcealBabySwallow : public Indicator {
 public:
   void calculate(const float *open, const float *high, const float *low,
@@ -10,5 +11,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Correl.h
+++ b/include/indicators/Correl.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Correl : public Indicator {
 public:
     explicit Correl(int period);
@@ -11,5 +12,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/CounterAttack.h
+++ b/include/indicators/CounterAttack.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class CounterAttack : public Indicator {
 public:
   void calculate(const float *open, const float *high, const float *low,
@@ -10,5 +11,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/DEMA.h
+++ b/include/indicators/DEMA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class DEMA : public Indicator {
 public:
     explicit DEMA(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/DX.h
+++ b/include/indicators/DX.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class DX : public Indicator {
 public:
     explicit DX(int period);
@@ -12,5 +13,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/DarkCloudCover.h
+++ b/include/indicators/DarkCloudCover.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class DarkCloudCover : public Indicator {
 public:
   void calculate(const float *open, const float *high, const float *low,
@@ -10,5 +11,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Doji.h
+++ b/include/indicators/Doji.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Doji : public Indicator {
 public:
     explicit Doji(float threshold = 0.1f);
@@ -12,5 +13,7 @@ public:
 private:
     float threshold;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/DojiStar.h
+++ b/include/indicators/DojiStar.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class DojiStar : public Indicator {
 public:
   DojiStar() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/DragonflyDoji.h
+++ b/include/indicators/DragonflyDoji.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class DragonflyDoji : public Indicator {
 public:
   DragonflyDoji() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/EMA.h
+++ b/include/indicators/EMA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class EMA : public Indicator {
 public:
     explicit EMA(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Engulfing.h
+++ b/include/indicators/Engulfing.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Engulfing : public Indicator {
 public:
   Engulfing() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/EveningDojiStar.h
+++ b/include/indicators/EveningDojiStar.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class EveningDojiStar : public Indicator {
 public:
   EveningDojiStar() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/EveningStar.h
+++ b/include/indicators/EveningStar.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class EveningStar : public Indicator {
 public:
   EveningStar() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/GapSideSideWhite.h
+++ b/include/indicators/GapSideSideWhite.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class GapSideSideWhite : public Indicator {
 public:
     GapSideSideWhite() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/GravestoneDoji.h
+++ b/include/indicators/GravestoneDoji.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class GravestoneDoji : public Indicator {
 public:
     GravestoneDoji() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/HT_DCPERIOD.h
+++ b/include/indicators/HT_DCPERIOD.h
@@ -3,10 +3,13 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HT_DCPERIOD : public Indicator {
 public:
     HT_DCPERIOD() = default;
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/HT_DCPHASE.h
+++ b/include/indicators/HT_DCPHASE.h
@@ -3,10 +3,13 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HT_DCPHASE : public Indicator {
 public:
     HT_DCPHASE() = default;
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/HT_PHASOR.h
+++ b/include/indicators/HT_PHASOR.h
@@ -3,10 +3,13 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HT_PHASOR : public Indicator {
 public:
     HT_PHASOR() = default;
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/HT_SINE.h
+++ b/include/indicators/HT_SINE.h
@@ -3,10 +3,13 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HT_SINE : public Indicator {
 public:
     HT_SINE() = default;
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/HT_TRENDLINE.h
+++ b/include/indicators/HT_TRENDLINE.h
@@ -3,10 +3,13 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HT_TRENDLINE : public Indicator {
 public:
     HT_TRENDLINE() = default;
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/HT_TRENDMODE.h
+++ b/include/indicators/HT_TRENDMODE.h
@@ -3,10 +3,13 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HT_TRENDMODE : public Indicator {
 public:
     HT_TRENDMODE() = default;
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Hammer.h
+++ b/include/indicators/Hammer.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Hammer : public Indicator {
 public:
     Hammer() = default;
@@ -10,5 +11,7 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/HangingMan.h
+++ b/include/indicators/HangingMan.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HangingMan : public Indicator {
 public:
     HangingMan() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/Harami.h
+++ b/include/indicators/Harami.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Harami : public Indicator {
 public:
     Harami() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/HaramiCross.h
+++ b/include/indicators/HaramiCross.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HaramiCross : public Indicator {
 public:
     HaramiCross() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/HighWave.h
+++ b/include/indicators/HighWave.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HighWave : public Indicator {
 public:
     HighWave() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/Hikkake.h
+++ b/include/indicators/Hikkake.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Hikkake : public Indicator {
 public:
     Hikkake() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/HikkakeMod.h
+++ b/include/indicators/HikkakeMod.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HikkakeMod : public Indicator {
 public:
     HikkakeMod() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/HomingPigeon.h
+++ b/include/indicators/HomingPigeon.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class HomingPigeon : public Indicator {
 public:
     HomingPigeon() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/IdenticalThreeCrows.h
+++ b/include/indicators/IdenticalThreeCrows.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class IdenticalThreeCrows : public Indicator {
 public:
   IdenticalThreeCrows() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/InNeck.h
+++ b/include/indicators/InNeck.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class InNeck : public Indicator {
 public:
   InNeck() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Indicator.h
+++ b/include/indicators/Indicator.h
@@ -3,11 +3,14 @@
 
 #include <cuda_runtime.h>
 
+namespace tacuda {
 class Indicator {
 public:
     virtual void calculate(const float* input, float* output, int size,
                            cudaStream_t stream = 0) noexcept(false) = 0;
     virtual ~Indicator() = default;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/InvertedHammer.h
+++ b/include/indicators/InvertedHammer.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class InvertedHammer : public Indicator {
 public:
     InvertedHammer() = default;
@@ -10,5 +11,7 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/KAMA.h
+++ b/include/indicators/KAMA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class KAMA : public Indicator {
 public:
   KAMA(int period, int fastPeriod, int slowPeriod);
@@ -14,5 +15,7 @@ private:
   float fastSC;
   float slowSC;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Kicking.h
+++ b/include/indicators/Kicking.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Kicking : public Indicator {
 public:
   Kicking() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/KickingByLength.h
+++ b/include/indicators/KickingByLength.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class KickingByLength : public Indicator {
 public:
   KickingByLength() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/LINEARREG.h
+++ b/include/indicators/LINEARREG.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class LINEARREG : public Indicator {
 public:
     explicit LINEARREG(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/LINEARREG_ANGLE.h
+++ b/include/indicators/LINEARREG_ANGLE.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class LINEARREG_ANGLE : public Indicator {
 public:
     explicit LINEARREG_ANGLE(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/LINEARREG_INTERCEPT.h
+++ b/include/indicators/LINEARREG_INTERCEPT.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class LINEARREG_INTERCEPT : public Indicator {
 public:
     explicit LINEARREG_INTERCEPT(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/LINEARREG_SLOPE.h
+++ b/include/indicators/LINEARREG_SLOPE.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class LINEARREG_SLOPE : public Indicator {
 public:
     explicit LINEARREG_SLOPE(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/LadderBottom.h
+++ b/include/indicators/LadderBottom.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class LadderBottom : public Indicator {
 public:
     LadderBottom() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/LongLeggedDoji.h
+++ b/include/indicators/LongLeggedDoji.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class LongLeggedDoji : public Indicator {
 public:
     LongLeggedDoji() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/LongLine.h
+++ b/include/indicators/LongLine.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class LongLine : public Indicator {
 public:
     LongLine() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/MA.h
+++ b/include/indicators/MA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 enum class MAType { SMA = 0, EMA = 1 };
 
 class MA : public Indicator {
@@ -13,5 +14,7 @@ private:
     int period;
     MAType type;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MACD.h
+++ b/include/indicators/MACD.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MACD : public Indicator {
 public:
     MACD(int fastPeriod, int slowPeriod);
@@ -11,5 +12,7 @@ private:
     int fastPeriod;
     int slowPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MACDEXT.h
+++ b/include/indicators/MACDEXT.h
@@ -4,6 +4,7 @@
 #include "Indicator.h"
 #include "MA.h"
 
+namespace tacuda {
 class MACDEXT : public Indicator {
 public:
     MACDEXT(int fastPeriod, int slowPeriod, int signalPeriod, MAType type);
@@ -14,5 +15,7 @@ private:
     int signalPeriod;
     MAType type;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MACDFIX.h
+++ b/include/indicators/MACDFIX.h
@@ -4,6 +4,7 @@
 #include "Indicator.h"
 #include "MA.h"
 
+namespace tacuda {
 class MACDFIX : public Indicator {
 public:
     explicit MACDFIX(int signalPeriod);
@@ -11,5 +12,7 @@ public:
 private:
     int signalPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MAMA.h
+++ b/include/indicators/MAMA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MAMA : public Indicator {
 public:
     MAMA(float fastLimit, float slowLimit);
@@ -11,5 +12,7 @@ private:
     float fastLimit;
     float slowLimit;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MAX.h
+++ b/include/indicators/MAX.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MAX : public Indicator {
 public:
     explicit MAX(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MAXINDEX.h
+++ b/include/indicators/MAXINDEX.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MAXINDEX : public Indicator {
 public:
     explicit MAXINDEX(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MFI.h
+++ b/include/indicators/MFI.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MFI : public Indicator {
 public:
     explicit MFI(int period);
@@ -12,5 +13,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MIDPOINT.h
+++ b/include/indicators/MIDPOINT.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MIDPOINT : public Indicator {
 public:
     explicit MIDPOINT(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MIDPRICE.h
+++ b/include/indicators/MIDPRICE.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MIDPRICE : public Indicator {
 public:
     explicit MIDPRICE(int period);
@@ -11,5 +12,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MIN.h
+++ b/include/indicators/MIN.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MIN : public Indicator {
 public:
     explicit MIN(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MININDEX.h
+++ b/include/indicators/MININDEX.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MININDEX : public Indicator {
 public:
   explicit MININDEX(int period);
@@ -12,5 +13,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MINMAX.h
+++ b/include/indicators/MINMAX.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MINMAX : public Indicator {
 public:
   explicit MINMAX(int period);
@@ -12,5 +13,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MINMAXINDEX.h
+++ b/include/indicators/MINMAXINDEX.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MINMAXINDEX : public Indicator {
 public:
   explicit MINMAXINDEX(int period);
@@ -12,5 +13,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Marubozu.h
+++ b/include/indicators/Marubozu.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Marubozu : public Indicator {
 public:
     Marubozu() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/MatHold.h
+++ b/include/indicators/MatHold.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MatHold : public Indicator {
 public:
   MatHold() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MatchingLow.h
+++ b/include/indicators/MatchingLow.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MatchingLow : public Indicator {
 public:
     MatchingLow() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/MedPrice.h
+++ b/include/indicators/MedPrice.h
@@ -3,11 +3,14 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MedPrice : public Indicator {
 public:
     MedPrice() = default;
     void calculate(const float* high, const float* low, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MinusDI.h
+++ b/include/indicators/MinusDI.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MinusDI : public Indicator {
 public:
   explicit MinusDI(int period);
@@ -14,5 +15,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MinusDM.h
+++ b/include/indicators/MinusDM.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MinusDM : public Indicator {
 public:
   explicit MinusDM(int period);
@@ -14,5 +15,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Momentum.h
+++ b/include/indicators/Momentum.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Momentum : public Indicator {
 public:
     explicit Momentum(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MorningDojiStar.h
+++ b/include/indicators/MorningDojiStar.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MorningDojiStar : public Indicator {
 public:
   MorningDojiStar() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/MorningStar.h
+++ b/include/indicators/MorningStar.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class MorningStar : public Indicator {
 public:
   MorningStar() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/NATR.h
+++ b/include/indicators/NATR.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class NATR : public Indicator {
 public:
   explicit NATR(int period);
@@ -14,5 +15,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/OBV.h
+++ b/include/indicators/OBV.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class OBV : public Indicator {
 public:
     OBV() = default;
@@ -10,5 +11,7 @@ public:
                    float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/OnNeck.h
+++ b/include/indicators/OnNeck.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class OnNeck : public Indicator {
 public:
   OnNeck() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/PPO.h
+++ b/include/indicators/PPO.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class PPO : public Indicator {
 public:
   PPO(int fastPeriod, int slowPeriod);
@@ -13,5 +14,7 @@ private:
   int fastPeriod;
   int slowPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/PVO.h
+++ b/include/indicators/PVO.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class PVO : public Indicator {
 public:
   PVO(int fastPeriod, int slowPeriod);
@@ -13,5 +14,7 @@ private:
   int fastPeriod;
   int slowPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Piercing.h
+++ b/include/indicators/Piercing.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Piercing : public Indicator {
 public:
   Piercing() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/PlusDI.h
+++ b/include/indicators/PlusDI.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class PlusDI : public Indicator {
 public:
   explicit PlusDI(int period);
@@ -14,5 +15,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/PlusDM.h
+++ b/include/indicators/PlusDM.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class PlusDM : public Indicator {
 public:
   explicit PlusDM(int period);
@@ -14,5 +15,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ROC.h
+++ b/include/indicators/ROC.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ROC : public Indicator {
 public:
     explicit ROC(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ROCP.h
+++ b/include/indicators/ROCP.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ROCP : public Indicator {
 public:
   explicit ROCP(int period);
@@ -12,5 +13,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ROCR.h
+++ b/include/indicators/ROCR.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ROCR : public Indicator {
 public:
   explicit ROCR(int period);
@@ -12,5 +13,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ROCR100.h
+++ b/include/indicators/ROCR100.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ROCR100 : public Indicator {
 public:
   explicit ROCR100(int period);
@@ -12,5 +13,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/RSI.h
+++ b/include/indicators/RSI.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class RSI : public Indicator {
 public:
     explicit RSI(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/RickshawMan.h
+++ b/include/indicators/RickshawMan.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class RickshawMan : public Indicator {
 public:
   RickshawMan() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/RiseFall3Methods.h
+++ b/include/indicators/RiseFall3Methods.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class RiseFall3Methods : public Indicator {
 public:
   RiseFall3Methods() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/SAR.h
+++ b/include/indicators/SAR.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class SAR : public Indicator {
 public:
     explicit SAR(float step, float maxAcceleration);
@@ -13,5 +14,7 @@ private:
     float step;
     float maxAcceleration;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/SAREXT.h
+++ b/include/indicators/SAREXT.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class SAREXT : public Indicator {
 public:
     SAREXT(float startValue, float offsetOnReverse,
@@ -16,5 +17,7 @@ private:
     float accInitLong, accLong, accMaxLong;
     float accInitShort, accShort, accMaxShort;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/SMA.h
+++ b/include/indicators/SMA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class SMA : public Indicator {
 public:
     explicit SMA(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/SUM.h
+++ b/include/indicators/SUM.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class SUM : public Indicator {
 public:
   explicit SUM(int period);
@@ -12,5 +13,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/SeparatingLines.h
+++ b/include/indicators/SeparatingLines.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class SeparatingLines : public Indicator {
 public:
   SeparatingLines() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ShootingStar.h
+++ b/include/indicators/ShootingStar.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ShootingStar : public Indicator {
 public:
   ShootingStar() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ShortLine.h
+++ b/include/indicators/ShortLine.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ShortLine : public Indicator {
 public:
   ShortLine() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/SpinningTop.h
+++ b/include/indicators/SpinningTop.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class SpinningTop : public Indicator {
 public:
     SpinningTop() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/StalledPattern.h
+++ b/include/indicators/StalledPattern.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class StalledPattern : public Indicator {
 public:
     StalledPattern() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/StdDev.h
+++ b/include/indicators/StdDev.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class StdDev : public Indicator {
 public:
     explicit StdDev(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/StickSandwich.h
+++ b/include/indicators/StickSandwich.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class StickSandwich : public Indicator {
 public:
     StickSandwich() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/StochRSI.h
+++ b/include/indicators/StochRSI.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class StochRSI : public Indicator {
 public:
   StochRSI(int rsiPeriod, int kPeriod, int dPeriod);
@@ -14,5 +15,7 @@ private:
   int kPeriod;
   int dPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Stochastic.h
+++ b/include/indicators/Stochastic.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Stochastic : public Indicator {
 public:
     Stochastic(int kPeriod, int dPeriod);
@@ -13,5 +14,7 @@ private:
     int kPeriod;
     int dPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/StochasticFast.h
+++ b/include/indicators/StochasticFast.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class StochasticFast : public Indicator {
 public:
     StochasticFast(int kPeriod, int dPeriod);
@@ -13,5 +14,7 @@ private:
     int kPeriod;
     int dPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/T3.h
+++ b/include/indicators/T3.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class T3 : public Indicator {
 public:
   T3(int period, float vFactor);
@@ -13,5 +14,7 @@ private:
   int period;
   float vFactor;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/TEMA.h
+++ b/include/indicators/TEMA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class TEMA : public Indicator {
 public:
     explicit TEMA(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/TRANGE.h
+++ b/include/indicators/TRANGE.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class TRANGE : public Indicator {
 public:
   TRANGE() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/TRIMA.h
+++ b/include/indicators/TRIMA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class TRIMA : public Indicator {
 public:
   explicit TRIMA(int period);
@@ -12,5 +13,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/TRIX.h
+++ b/include/indicators/TRIX.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class TRIX : public Indicator {
 public:
     explicit TRIX(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/TSF.h
+++ b/include/indicators/TSF.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class TSF : public Indicator {
 public:
     explicit TSF(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Takuri.h
+++ b/include/indicators/Takuri.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Takuri : public Indicator {
 public:
     Takuri() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/TasukiGap.h
+++ b/include/indicators/TasukiGap.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class TasukiGap : public Indicator {
 public:
     TasukiGap() = default;
@@ -11,6 +12,8 @@ public:
     void calculate(const float* input, float* output,
                    int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/ThreeBlackCrows.h
+++ b/include/indicators/ThreeBlackCrows.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ThreeBlackCrows : public Indicator {
 public:
     ThreeBlackCrows() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/ThreeInside.h
+++ b/include/indicators/ThreeInside.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ThreeInside : public Indicator {
 public:
     ThreeInside() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/ThreeLineStrike.h
+++ b/include/indicators/ThreeLineStrike.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ThreeLineStrike : public Indicator {
 public:
     ThreeLineStrike() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/ThreeStarsInSouth.h
+++ b/include/indicators/ThreeStarsInSouth.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ThreeStarsInSouth : public Indicator {
 public:
     ThreeStarsInSouth() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/ThreeWhiteSoldiers.h
+++ b/include/indicators/ThreeWhiteSoldiers.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ThreeWhiteSoldiers : public Indicator {
 public:
     ThreeWhiteSoldiers() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/Thrusting.h
+++ b/include/indicators/Thrusting.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Thrusting : public Indicator {
 public:
   Thrusting() = default;
@@ -11,6 +12,8 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/Tristar.h
+++ b/include/indicators/Tristar.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Tristar : public Indicator {
 public:
   Tristar() = default;
@@ -11,6 +12,8 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/TwoCrows.h
+++ b/include/indicators/TwoCrows.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class TwoCrows : public Indicator {
 public:
     TwoCrows() = default;
@@ -10,6 +11,8 @@ public:
                    const float* close, float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/TypPrice.h
+++ b/include/indicators/TypPrice.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class TypPrice : public Indicator {
 public:
     TypPrice() = default;
@@ -10,5 +11,7 @@ public:
                    float* output, int size, cudaStream_t stream = 0) noexcept(false);
     void calculate(const float* input, float* output, int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/ULTOSC.h
+++ b/include/indicators/ULTOSC.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class ULTOSC : public Indicator {
 public:
     ULTOSC(int shortPeriod, int mediumPeriod, int longPeriod);
@@ -14,5 +15,7 @@ private:
     int mediumPeriod;
     int longPeriod;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/Unique3River.h
+++ b/include/indicators/Unique3River.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class Unique3River : public Indicator {
 public:
   Unique3River() = default;
@@ -11,6 +12,8 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/UpsideGap2Crows.h
+++ b/include/indicators/UpsideGap2Crows.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class UpsideGap2Crows : public Indicator {
 public:
   UpsideGap2Crows() = default;
@@ -11,6 +12,8 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/include/indicators/VAR.h
+++ b/include/indicators/VAR.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class VAR : public Indicator {
 public:
     explicit VAR(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/WILLR.h
+++ b/include/indicators/WILLR.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class WILLR : public Indicator {
 public:
   explicit WILLR(int period);
@@ -14,5 +15,7 @@ public:
 private:
   int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/WMA.h
+++ b/include/indicators/WMA.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class WMA : public Indicator {
 public:
     explicit WMA(int period);
@@ -10,5 +11,7 @@ public:
 private:
     int period;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/WclPrice.h
+++ b/include/indicators/WclPrice.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class WclPrice : public Indicator {
 public:
   WclPrice() = default;
@@ -11,5 +12,7 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif

--- a/include/indicators/XSideGap3Methods.h
+++ b/include/indicators/XSideGap3Methods.h
@@ -3,6 +3,7 @@
 
 #include "Indicator.h"
 
+namespace tacuda {
 class XSideGap3Methods : public Indicator {
 public:
   XSideGap3Methods() = default;
@@ -11,6 +12,8 @@ public:
   void calculate(const float *input, float *output,
                  int size, cudaStream_t stream = 0) noexcept(false) override;
 };
+
+} // namespace tacuda
 
 #endif
 

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -156,7 +156,7 @@ struct PooledDeleter {
 };
 using DeviceBuffer = std::unique_ptr<float, PooledDeleter>;
 
-static ctStatus_t run_indicator(Indicator &ind, const float *h_in, float *h_out,
+static ctStatus_t run_indicator(tacuda::Indicator &ind, const float *h_in, float *h_out,
                                 int size, int outMultiple = 1,
                                 cudaStream_t stream = 0) {
   DeviceBuffer d_in{nullptr}, d_out{nullptr};
@@ -382,121 +382,121 @@ extern "C" {
 
 ctStatus_t ct_sma(const float *host_input, float *host_output, int size,
                   int period) {
-  SMA sma(period);
+  tacuda::SMA sma(period);
   return run_indicator(sma, host_input, host_output, size);
 }
 
 ctStatus_t ct_ma(const float *host_input, float *host_output, int size,
                  int period, ctMaType_t type) {
-  MA ma(period, static_cast<MAType>(type));
+  tacuda::MA ma(period, static_cast<tacuda::MAType>(type));
   return run_indicator(ma, host_input, host_output, size);
 }
 
 ctStatus_t ct_wma(const float *host_input, float *host_output, int size,
                   int period) {
-  WMA wma(period);
+  tacuda::WMA wma(period);
   return run_indicator(wma, host_input, host_output, size);
 }
 
 ctStatus_t ct_momentum(const float *host_input, float *host_output, int size,
                        int period) {
-  Momentum mom(period);
+  tacuda::Momentum mom(period);
   return run_indicator(mom, host_input, host_output, size);
 }
 
 ctStatus_t ct_change(const float *host_input, float *host_output, int size,
                      int period) {
-  Change ch(period);
+  tacuda::Change ch(period);
   return run_indicator(ch, host_input, host_output, size);
 }
 
 ctStatus_t ct_roc(const float *host_input, float *host_output, int size,
                   int period) {
-  ROC roc(period);
+  tacuda::ROC roc(period);
   return run_indicator(roc, host_input, host_output, size);
 }
 
 ctStatus_t ct_rocp(const float *host_input, float *host_output, int size,
                    int period) {
-  ROCP rocp(period);
+  tacuda::ROCP rocp(period);
   return run_indicator(rocp, host_input, host_output, size);
 }
 
 ctStatus_t ct_rocr(const float *host_input, float *host_output, int size,
                    int period) {
-  ROCR rocr(period);
+  tacuda::ROCR rocr(period);
   return run_indicator(rocr, host_input, host_output, size);
 }
 
 ctStatus_t ct_rocr100(const float *host_input, float *host_output, int size,
                       int period) {
-  ROCR100 rocr100(period);
+  tacuda::ROCR100 rocr100(period);
   return run_indicator(rocr100, host_input, host_output, size);
 }
 
 ctStatus_t ct_ema(const float *host_input, float *host_output, int size,
                   int period) {
-  EMA ema(period);
+  tacuda::EMA ema(period);
   return run_indicator(ema, host_input, host_output, size);
 }
 
 ctStatus_t ct_dema(const float *host_input, float *host_output, int size,
                    int period) {
-  DEMA dema(period);
+  tacuda::DEMA dema(period);
   return run_indicator(dema, host_input, host_output, size);
 }
 
 ctStatus_t ct_tema(const float *host_input, float *host_output, int size,
                    int period) {
-  TEMA tema(period);
+  tacuda::TEMA tema(period);
   return run_indicator(tema, host_input, host_output, size);
 }
 
 ctStatus_t ct_t3(const float *host_input, float *host_output, int size,
                  int period, float vFactor) {
-  T3 t3(period, vFactor);
+  tacuda::T3 t3(period, vFactor);
   return run_indicator(t3, host_input, host_output, size);
 }
 
 ctStatus_t ct_trima(const float *host_input, float *host_output, int size,
                     int period) {
-  TRIMA trima(period);
+  tacuda::TRIMA trima(period);
   return run_indicator(trima, host_input, host_output, size);
 }
 
 ctStatus_t ct_trix(const float *host_input, float *host_output, int size,
                    int period) {
-  TRIX trix(period);
+  tacuda::TRIX trix(period);
   return run_indicator(trix, host_input, host_output, size);
 }
 
 ctStatus_t ct_max(const float *host_input, float *host_output, int size,
                   int period) {
-  MAX mx(period);
+  tacuda::MAX mx(period);
   return run_indicator(mx, host_input, host_output, size);
 }
 
 ctStatus_t ct_min(const float *host_input, float *host_output, int size,
                   int period) {
-  MIN mn(period);
+  tacuda::MIN mn(period);
   return run_indicator(mn, host_input, host_output, size);
 }
 
 ctStatus_t ct_maxindex(const float *host_input, float *host_output, int size,
                        int period) {
-  MAXINDEX mi(period);
+  tacuda::MAXINDEX mi(period);
   return run_indicator(mi, host_input, host_output, size);
 }
 
 ctStatus_t ct_minindex(const float *host_input, float *host_output, int size,
                        int period) {
-  MININDEX mi(period);
+  tacuda::MININDEX mi(period);
   return run_indicator(mi, host_input, host_output, size);
 }
 
 ctStatus_t ct_minmax(const float *host_input, float *host_min, float *host_max,
                      int size, int period) {
-  MINMAX mm(period);
+  tacuda::MINMAX mm(period);
   std::vector<float> tmp(2 * size);
   ctStatus_t rc = run_indicator(mm, host_input, tmp.data(), size, 2);
   if (rc != CT_STATUS_SUCCESS)
@@ -508,7 +508,7 @@ ctStatus_t ct_minmax(const float *host_input, float *host_min, float *host_max,
 
 ctStatus_t ct_minmaxindex(const float *host_input, float *host_minidx,
                           float *host_maxidx, int size, int period) {
-  MINMAXINDEX mm(period);
+  tacuda::MINMAXINDEX mm(period);
   std::vector<float> tmp(2 * size);
   ctStatus_t rc = run_indicator(mm, host_input, tmp.data(), size, 2);
   if (rc != CT_STATUS_SUCCESS)
@@ -520,37 +520,37 @@ ctStatus_t ct_minmaxindex(const float *host_input, float *host_minidx,
 
 ctStatus_t ct_stddev(const float *host_input, float *host_output, int size,
                      int period) {
-  StdDev sd(period);
+  tacuda::StdDev sd(period);
   return run_indicator(sd, host_input, host_output, size);
 }
 
 ctStatus_t ct_var(const float *host_input, float *host_output, int size,
                   int period) {
-  VAR vr(period);
+  tacuda::VAR vr(period);
   return run_indicator(vr, host_input, host_output, size);
 }
 
 ctStatus_t ct_sum(const float *host_input, float *host_output, int size,
                   int period) {
-  SUM sum(period);
+  tacuda::SUM sum(period);
   return run_indicator(sum, host_input, host_output, size);
 }
 
 ctStatus_t ct_rsi(const float *host_input, float *host_output, int size,
                   int period) {
-  RSI rsi(period);
+  tacuda::RSI rsi(period);
   return run_indicator(rsi, host_input, host_output, size);
 }
 
 ctStatus_t ct_kama(const float *host_input, float *host_output, int size,
                    int period, int fastPeriod, int slowPeriod) {
-  KAMA kama(period, fastPeriod, slowPeriod);
+  tacuda::KAMA kama(period, fastPeriod, slowPeriod);
   return run_indicator(kama, host_input, host_output, size);
 }
 
 ctStatus_t ct_macd_line(const float *host_input, float *host_output, int size,
                         int fastPeriod, int slowPeriod) {
-  MACD macd(fastPeriod, slowPeriod);
+  tacuda::MACD macd(fastPeriod, slowPeriod);
   return run_indicator(macd, host_input, host_output, size);
 }
 
@@ -558,7 +558,7 @@ ctStatus_t ct_macd(const float *host_input, float *host_macd,
                    float *host_signal, float *host_hist, int size,
                    int fastPeriod, int slowPeriod, int signalPeriod,
                    ctMaType_t type) {
-  MACDEXT macd(fastPeriod, slowPeriod, signalPeriod, static_cast<MAType>(type));
+  tacuda::MACDEXT macd(fastPeriod, slowPeriod, signalPeriod, static_cast<tacuda::MAType>(type));
   std::vector<float> tmp(3 * size);
   ctStatus_t rc = run_indicator(macd, host_input, tmp.data(), size, 3);
   if (rc != CT_STATUS_SUCCESS)
@@ -572,7 +572,7 @@ ctStatus_t ct_macd(const float *host_input, float *host_macd,
 ctStatus_t ct_macdfix(const float *host_input, float *host_macd,
                       float *host_signal, float *host_hist, int size,
                       int signalPeriod) {
-  MACDFIX macd(signalPeriod);
+  tacuda::MACDFIX macd(signalPeriod);
   std::vector<float> tmp(3 * size);
   ctStatus_t rc = run_indicator(macd, host_input, tmp.data(), size, 3);
   if (rc != CT_STATUS_SUCCESS)
@@ -585,7 +585,7 @@ ctStatus_t ct_macdfix(const float *host_input, float *host_macd,
 
 ctStatus_t ct_mama(const float *host_input, float *host_mama, float *host_fama,
                    int size, float fastLimit, float slowLimit) {
-  MAMA ma(fastLimit, slowLimit);
+  tacuda::MAMA ma(fastLimit, slowLimit);
   std::vector<float> tmp(2 * size);
   ctStatus_t rc = run_indicator(ma, host_input, tmp.data(), size, 2);
   if (rc != CT_STATUS_SUCCESS)
@@ -597,26 +597,26 @@ ctStatus_t ct_mama(const float *host_input, float *host_mama, float *host_fama,
 
 ctStatus_t ct_apo(const float *host_input, float *host_output, int size,
                   int fastPeriod, int slowPeriod) {
-  APO apo(fastPeriod, slowPeriod);
+  tacuda::APO apo(fastPeriod, slowPeriod);
   return run_indicator(apo, host_input, host_output, size);
 }
 
 ctStatus_t ct_ppo(const float *host_input, float *host_output, int size,
                   int fastPeriod, int slowPeriod) {
-  PPO ppo(fastPeriod, slowPeriod);
+  tacuda::PPO ppo(fastPeriod, slowPeriod);
   return run_indicator(ppo, host_input, host_output, size);
 }
 
 ctStatus_t ct_pvo(const float *host_volume, float *host_output, int size,
                   int fastPeriod, int slowPeriod) {
-  PVO pvo(fastPeriod, slowPeriod);
+  tacuda::PVO pvo(fastPeriod, slowPeriod);
   return run_indicator(pvo, host_volume, host_output, size);
 }
 
 ctStatus_t ct_bbands(const float *host_input, float *host_upper,
                      float *host_middle, float *host_lower, int size,
                      int period, float upperMul, float lowerMul) {
-  BBANDS bb(period, upperMul, lowerMul);
+  tacuda::BBANDS bb(period, upperMul, lowerMul);
   std::vector<float> tmp(3 * size);
   ctStatus_t rc = run_indicator(bb, host_input, tmp.data(), size, 3);
   if (rc != CT_STATUS_SUCCESS) {
@@ -631,7 +631,7 @@ ctStatus_t ct_bbands(const float *host_input, float *host_upper,
 ctStatus_t ct_atr(const float *host_high, const float *host_low,
                   const float *host_close, float *host_output, int size,
                   int period, float initial, cudaStream_t stream) {
-  ATR atr(period, initial);
+  tacuda::ATR atr(period, initial);
   return run_ohlc_indicator(atr, host_high, host_low, host_close,
                             host_output, size, 1, stream);
 }
@@ -639,7 +639,7 @@ ctStatus_t ct_atr(const float *host_high, const float *host_low,
 ctStatus_t ct_natr(const float *host_high, const float *host_low,
                    const float *host_close, float *host_output, int size,
                    int period, cudaStream_t stream) {
-  NATR natr(period);
+  tacuda::NATR natr(period);
   return run_ohlc_indicator(natr, host_high, host_low, host_close,
                             host_output, size, 1, stream);
 }
@@ -647,7 +647,7 @@ ctStatus_t ct_natr(const float *host_high, const float *host_low,
 ctStatus_t ct_trange(const float *host_high, const float *host_low,
                      const float *host_close, float *host_output, int size,
                      cudaStream_t stream) {
-  TRANGE tr;
+  tacuda::TRANGE tr;
   return run_ohlc_indicator(tr, host_high, host_low, host_close, host_output,
                             size, 1, stream);
 }
@@ -656,7 +656,7 @@ ctStatus_t ct_stochastic(const float *host_high, const float *host_low,
                          const float *host_close, float *host_k, float *host_d,
                          int size, int kPeriod, int dPeriod,
                          cudaStream_t stream) {
-  Stochastic stoch(kPeriod, dPeriod);
+  tacuda::Stochastic stoch(kPeriod, dPeriod);
   std::vector<float> tmp(2 * size);
   ctStatus_t rc = run_ohlc_indicator(stoch, host_high, host_low, host_close,
                                      tmp.data(), size, 2, stream);
@@ -671,7 +671,7 @@ ctStatus_t ct_stochf(const float *host_high, const float *host_low,
                      const float *host_close, float *host_k, float *host_d,
                      int size, int kPeriod, int dPeriod,
                      cudaStream_t stream) {
-  StochasticFast stoch(kPeriod, dPeriod);
+  tacuda::StochasticFast stoch(kPeriod, dPeriod);
   std::vector<float> tmp(2 * size);
   ctStatus_t rc = run_ohlc_indicator(stoch, host_high, host_low, host_close,
                                      tmp.data(), size, 2, stream);
@@ -685,7 +685,7 @@ ctStatus_t ct_stochf(const float *host_high, const float *host_low,
 ctStatus_t ct_stochrsi(const float *host_input, float *host_k, float *host_d,
                        int size, int rsiPeriod, int kPeriod, int dPeriod,
                        cudaStream_t stream) {
-  StochRSI st(rsiPeriod, kPeriod, dPeriod);
+  tacuda::StochRSI st(rsiPeriod, kPeriod, dPeriod);
   std::vector<float> tmp(2 * size);
   ctStatus_t rc = run_indicator(st, host_input, tmp.data(), size, 2, stream);
   if (rc != CT_STATUS_SUCCESS)
@@ -698,7 +698,7 @@ ctStatus_t ct_stochrsi(const float *host_input, float *host_k, float *host_d,
 ctStatus_t ct_cci(const float *host_high, const float *host_low,
                   const float *host_close, float *host_output, int size,
                   int period, cudaStream_t stream) {
-  CCI cci(period);
+  tacuda::CCI cci(period);
   return run_ohlc_indicator(cci, host_high, host_low, host_close, host_output,
                             size, 1, stream);
 }
@@ -706,7 +706,7 @@ ctStatus_t ct_cci(const float *host_high, const float *host_low,
 ctStatus_t ct_adx(const float *host_high, const float *host_low,
                   const float *host_close, float *host_output, int size,
                   int period, cudaStream_t stream) {
-  ADX adx(period);
+  tacuda::ADX adx(period);
   return run_ohlc_indicator(adx, host_high, host_low, host_close, host_output,
                             size, 1, stream);
 }
@@ -714,14 +714,14 @@ ctStatus_t ct_adx(const float *host_high, const float *host_low,
 ctStatus_t ct_adxr(const float *host_high, const float *host_low,
                    const float *host_close, float *host_output, int size,
                    int period, cudaStream_t stream) {
-  ADXR adxr(period);
+  tacuda::ADXR adxr(period);
   return run_ohlc_indicator(adxr, host_high, host_low, host_close,
                             host_output, size, 1, stream);
 }
 
 ctStatus_t ct_plus_dm(const float *host_high, const float *host_low,
                       float *host_output, int size, int period) {
-  PlusDM pdm(period);
+  tacuda::PlusDM pdm(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -771,7 +771,7 @@ ctStatus_t ct_plus_dm(const float *host_high, const float *host_low,
 
 ctStatus_t ct_minus_dm(const float *host_high, const float *host_low,
                        float *host_output, int size, int period) {
-  MinusDM mdm(period);
+  tacuda::MinusDM mdm(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -822,7 +822,7 @@ ctStatus_t ct_minus_dm(const float *host_high, const float *host_low,
 ctStatus_t ct_plus_di(const float *host_high, const float *host_low,
                       const float *host_close, float *host_output, int size,
                       int period, cudaStream_t stream) {
-  PlusDI pdi(period);
+  tacuda::PlusDI pdi(period);
   return run_ohlc_indicator(pdi, host_high, host_low, host_close, host_output,
                             size, 1, stream);
 }
@@ -830,7 +830,7 @@ ctStatus_t ct_plus_di(const float *host_high, const float *host_low,
 ctStatus_t ct_minus_di(const float *host_high, const float *host_low,
                        const float *host_close, float *host_output, int size,
                        int period, cudaStream_t stream) {
-  MinusDI mdi(period);
+  tacuda::MinusDI mdi(period);
   return run_ohlc_indicator(mdi, host_high, host_low, host_close, host_output,
                             size, 1, stream);
 }
@@ -838,7 +838,7 @@ ctStatus_t ct_minus_di(const float *host_high, const float *host_low,
 ctStatus_t ct_sar(const float *host_high, const float *host_low,
                   float *host_output, int size, float step,
                   float maxAcceleration) {
-  SAR sar(step, maxAcceleration);
+  tacuda::SAR sar(step, maxAcceleration);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -891,7 +891,7 @@ ctStatus_t ct_sarext(const float *host_high, const float *host_low,
                      float offsetOnReverse, float accInitLong, float accLong,
                      float accMaxLong, float accInitShort, float accShort,
                      float accMaxShort) {
-  SAREXT sar(startValue, offsetOnReverse, accInitLong, accLong, accMaxLong,
+  tacuda::SAREXT sar(startValue, offsetOnReverse, accInitLong, accLong, accMaxLong,
              accInitShort, accShort, accMaxShort);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -943,7 +943,7 @@ ctStatus_t ct_sarext(const float *host_high, const float *host_low,
 ctStatus_t ct_aroon(const float *host_high, const float *host_low,
                     float *host_up, float *host_down, float *host_osc, int size,
                     int upPeriod, int downPeriod) {
-  Aroon aroon(upPeriod, downPeriod);
+  tacuda::Aroon aroon(upPeriod, downPeriod);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -998,7 +998,7 @@ ctStatus_t ct_aroon(const float *host_high, const float *host_low,
 
 ctStatus_t ct_aroonosc(const float *host_high, const float *host_low,
                        float *host_output, int size, int period) {
-  AroonOscillator ind(period);
+  tacuda::AroonOscillator ind(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -1050,7 +1050,7 @@ ctStatus_t ct_adosc(const float *host_high, const float *host_low,
                     const float *host_close, const float *host_volume,
                     float *host_output, int size, int shortPeriod,
                     int longPeriod) {
-  ADOSC adosc(shortPeriod, longPeriod);
+  tacuda::ADOSC adosc(shortPeriod, longPeriod);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_vol{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1125,7 +1125,7 @@ ctStatus_t ct_adosc(const float *host_high, const float *host_low,
 ctStatus_t ct_ad(const float *host_high, const float *host_low,
                  const float *host_close, const float *host_volume,
                  float *host_output, int size) {
-  AD ad;
+  tacuda::AD ad;
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_vol{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1200,7 +1200,7 @@ ctStatus_t ct_ad(const float *host_high, const float *host_low,
 ctStatus_t ct_avgprice(const float *host_open, const float *host_high,
                        const float *host_low, const float *host_close,
                        float *host_output, int size) {
-  AvgPrice ap;
+  tacuda::AvgPrice ap;
   DeviceBuffer d_open{nullptr}, d_high{nullptr}, d_low{nullptr},
       d_close{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1274,7 +1274,7 @@ ctStatus_t ct_avgprice(const float *host_open, const float *host_high,
 
 ctStatus_t ct_medprice(const float *host_high, const float *host_low,
                        float *host_output, int size) {
-  MedPrice mp;
+  tacuda::MedPrice mp;
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -1324,7 +1324,7 @@ ctStatus_t ct_medprice(const float *host_high, const float *host_low,
 
 ctStatus_t ct_typprice(const float *host_high, const float *host_low,
                        const float *host_close, float *host_output, int size) {
-  TypPrice tp;
+  tacuda::TypPrice tp;
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_out{nullptr};
   float *tmp = nullptr;
@@ -1386,7 +1386,7 @@ ctStatus_t ct_typprice(const float *host_high, const float *host_low,
 
 ctStatus_t ct_wclprice(const float *host_high, const float *host_low,
                        const float *host_close, float *host_output, int size) {
-  WclPrice wc;
+  tacuda::WclPrice wc;
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_out{nullptr};
   float *tmp = nullptr;
@@ -1449,7 +1449,7 @@ ctStatus_t ct_wclprice(const float *host_high, const float *host_low,
 ctStatus_t ct_willr(const float *host_high, const float *host_low,
                     const float *host_close, float *host_output, int size,
                     int period) {
-  WILLR willr(period);
+  tacuda::WILLR willr(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_out{nullptr};
   float *tmp = nullptr;
@@ -1512,13 +1512,13 @@ ctStatus_t ct_willr(const float *host_high, const float *host_low,
 
 ctStatus_t ct_midpoint(const float *host_input, float *host_output, int size,
                        int period) {
-  MIDPOINT mp(period);
+  tacuda::MIDPOINT mp(period);
   return run_indicator(mp, host_input, host_output, size);
 }
 
 ctStatus_t ct_midprice(const float *host_high, const float *host_low,
                        float *host_output, int size, int period) {
-  MIDPRICE mp(period);
+  tacuda::MIDPRICE mp(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
   cudaError_t err = cudaMalloc(&tmp, size * sizeof(float));
@@ -1556,7 +1556,7 @@ ctStatus_t ct_midprice(const float *host_high, const float *host_low,
 ctStatus_t ct_ultosc(const float *host_high, const float *host_low,
                      const float *host_close, float *host_output, int size,
                      int shortPeriod, int mediumPeriod, int longPeriod) {
-  ULTOSC ultosc(shortPeriod, mediumPeriod, longPeriod);
+  tacuda::ULTOSC ultosc(shortPeriod, mediumPeriod, longPeriod);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_out{nullptr};
   float *tmp = nullptr;
@@ -1620,7 +1620,7 @@ ctStatus_t ct_ultosc(const float *host_high, const float *host_low,
 ctStatus_t ct_mfi(const float *host_high, const float *host_low,
                   const float *host_close, const float *host_volume,
                   float *host_output, int size, int period) {
-  MFI mfi(period);
+  tacuda::MFI mfi(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_vol{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1694,7 +1694,7 @@ ctStatus_t ct_mfi(const float *host_high, const float *host_low,
 
 ctStatus_t ct_obv(const float *host_price, const float *host_volume,
                   float *host_output, int size) {
-  OBV obv;
+  tacuda::OBV obv;
   DeviceBuffer d_price{nullptr}, d_volume{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -1744,7 +1744,7 @@ ctStatus_t ct_obv(const float *host_price, const float *host_volume,
 
 ctStatus_t ct_beta(const float *host_x, const float *host_y, float *host_output,
                    int size, int period) {
-  Beta beta(period);
+  tacuda::Beta beta(period);
   DeviceBuffer d_x{nullptr}, d_y{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -1794,19 +1794,19 @@ ctStatus_t ct_beta(const float *host_x, const float *host_y, float *host_output,
 
 ctStatus_t ct_ht_dcperiod(const float *host_input, float *host_output,
                           int size) {
-  HT_DCPERIOD ind;
+  tacuda::HT_DCPERIOD ind;
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_ht_dcphase(const float *host_input, float *host_output,
                          int size) {
-  HT_DCPHASE ind;
+  tacuda::HT_DCPHASE ind;
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_ht_phasor(const float *host_input, float *host_inphase,
                         float *host_quadrature, int size) {
-  HT_PHASOR ind;
+  tacuda::HT_PHASOR ind;
   std::vector<float> tmp(2 * size);
   ctStatus_t rc = run_indicator(ind, host_input, tmp.data(), size, 2);
   if (rc != CT_STATUS_SUCCESS)
@@ -1818,7 +1818,7 @@ ctStatus_t ct_ht_phasor(const float *host_input, float *host_inphase,
 
 ctStatus_t ct_ht_sine(const float *host_input, float *host_sine,
                       float *host_leadsine, int size) {
-  HT_SINE ind;
+  tacuda::HT_SINE ind;
   std::vector<float> tmp(2 * size);
   ctStatus_t rc = run_indicator(ind, host_input, tmp.data(), size, 2);
   if (rc != CT_STATUS_SUCCESS)
@@ -1830,50 +1830,50 @@ ctStatus_t ct_ht_sine(const float *host_input, float *host_sine,
 
 ctStatus_t ct_ht_trendline(const float *host_input, float *host_output,
                            int size) {
-  HT_TRENDLINE ind;
+  tacuda::HT_TRENDLINE ind;
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_ht_trendmode(const float *host_input, float *host_output,
                            int size) {
-  HT_TRENDMODE ind;
+  tacuda::HT_TRENDMODE ind;
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_linearreg(const float *host_input, float *host_output, int size,
                         int period) {
-  LINEARREG ind(period);
+  tacuda::LINEARREG ind(period);
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_linearreg_slope(const float *host_input, float *host_output,
                               int size, int period) {
-  LINEARREG_SLOPE ind(period);
+  tacuda::LINEARREG_SLOPE ind(period);
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_linearreg_intercept(const float *host_input, float *host_output,
                                   int size, int period) {
-  LINEARREG_INTERCEPT ind(period);
+  tacuda::LINEARREG_INTERCEPT ind(period);
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_linearreg_angle(const float *host_input, float *host_output,
                               int size, int period) {
-  LINEARREG_ANGLE ind(period);
+  tacuda::LINEARREG_ANGLE ind(period);
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_tsf(const float *host_input, float *host_output, int size,
                   int period) {
-  TSF ind(period);
+  tacuda::TSF ind(period);
   return run_indicator(ind, host_input, host_output, size);
 }
 
 ctStatus_t ct_bop(const float *host_open, const float *host_high,
                   const float *host_low, const float *host_close,
                   float *host_output, int size) {
-  BOP bop;
+  tacuda::BOP bop;
   return run_ohlc_indicator(bop, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1881,7 +1881,7 @@ ctStatus_t ct_bop(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_doji(const float *host_open, const float *host_high,
                        const float *host_low, const float *host_close,
                        float *host_output, int size) {
-  Doji ind;
+  tacuda::Doji ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1889,7 +1889,7 @@ ctStatus_t ct_cdl_doji(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_hammer(const float *host_open, const float *host_high,
                          const float *host_low, const float *host_close,
                          float *host_output, int size) {
-  Hammer ind;
+  tacuda::Hammer ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1898,7 +1898,7 @@ ctStatus_t ct_cdl_inverted_hammer(const float *host_open,
                                   const float *host_high, const float *host_low,
                                   const float *host_close, float *host_output,
                                   int size) {
-  InvertedHammer ind;
+  tacuda::InvertedHammer ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1908,7 +1908,7 @@ ctStatus_t ct_cdl_bullish_engulfing(const float *host_open,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
                                     int size) {
-  BullishEngulfing ind;
+  tacuda::BullishEngulfing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1918,7 +1918,7 @@ ctStatus_t ct_cdl_bearish_engulfing(const float *host_open,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
                                     int size) {
-  BearishEngulfing ind;
+  tacuda::BearishEngulfing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1928,7 +1928,7 @@ ctStatus_t ct_cdl_three_white_soldiers(const float *host_open,
                                        const float *host_low,
                                        const float *host_close,
                                        float *host_output, int size) {
-  ThreeWhiteSoldiers ind;
+  tacuda::ThreeWhiteSoldiers ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1936,7 +1936,7 @@ ctStatus_t ct_cdl_three_white_soldiers(const float *host_open,
 ctStatus_t ct_cdl_abandoned_baby(const float *host_open, const float *host_high,
                                  const float *host_low, const float *host_close,
                                  float *host_output, int size) {
-  AbandonedBaby ind;
+  tacuda::AbandonedBaby ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1944,7 +1944,7 @@ ctStatus_t ct_cdl_abandoned_baby(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_advance_block(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
                                 float *host_output, int size) {
-  AdvanceBlock ind;
+  tacuda::AdvanceBlock ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1952,7 +1952,7 @@ ctStatus_t ct_cdl_advance_block(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_belt_hold(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
                             float *host_output, int size) {
-  BeltHold ind;
+  tacuda::BeltHold ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1960,7 +1960,7 @@ ctStatus_t ct_cdl_belt_hold(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_breakaway(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
                             float *host_output, int size) {
-  Breakaway ind;
+  tacuda::Breakaway ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1968,7 +1968,7 @@ ctStatus_t ct_cdl_breakaway(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_two_crows(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
                             float *host_output, int size) {
-  TwoCrows ind;
+  tacuda::TwoCrows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1978,7 +1978,7 @@ ctStatus_t ct_cdl_three_black_crows(const float *host_open,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
                                     int size) {
-  ThreeBlackCrows ind;
+  tacuda::ThreeBlackCrows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1986,7 +1986,7 @@ ctStatus_t ct_cdl_three_black_crows(const float *host_open,
 ctStatus_t ct_cdl_three_inside(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size) {
-  ThreeInside ind;
+  tacuda::ThreeInside ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -1996,7 +1996,7 @@ ctStatus_t ct_cdl_three_line_strike(const float *host_open,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
                                     int size) {
-  ThreeLineStrike ind;
+  tacuda::ThreeLineStrike ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2006,7 +2006,7 @@ ctStatus_t ct_cdl_three_stars_in_south(const float *host_open,
                                        const float *host_low,
                                        const float *host_close,
                                        float *host_output, int size) {
-  ThreeStarsInSouth ind;
+  tacuda::ThreeStarsInSouth ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2016,7 +2016,7 @@ ctStatus_t ct_cdl_closing_marubozu(const float *host_open,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
                                    int size) {
-  ClosingMarubozu ind;
+  tacuda::ClosingMarubozu ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2026,7 +2026,7 @@ ctStatus_t ct_cdl_conceal_baby_swallow(const float *host_open,
                                        const float *host_low,
                                        const float *host_close,
                                        float *host_output, int size) {
-  ConcealBabySwallow ind;
+  tacuda::ConcealBabySwallow ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2034,7 +2034,7 @@ ctStatus_t ct_cdl_conceal_baby_swallow(const float *host_open,
 ctStatus_t ct_cdl_counterattack(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
                                 float *host_output, int size) {
-  CounterAttack ind;
+  tacuda::CounterAttack ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2044,7 +2044,7 @@ ctStatus_t ct_cdl_dark_cloud_cover(const float *host_open,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
                                    int size) {
-  DarkCloudCover ind;
+  tacuda::DarkCloudCover ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2052,7 +2052,7 @@ ctStatus_t ct_cdl_dark_cloud_cover(const float *host_open,
 ctStatus_t ct_cdl_doji_star(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
                             float *host_output, int size) {
-  DojiStar ind;
+  tacuda::DojiStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2060,7 +2060,7 @@ ctStatus_t ct_cdl_doji_star(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_dragonfly_doji(const float *host_open, const float *host_high,
                                  const float *host_low, const float *host_close,
                                  float *host_output, int size) {
-  DragonflyDoji ind;
+  tacuda::DragonflyDoji ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2068,7 +2068,7 @@ ctStatus_t ct_cdl_dragonfly_doji(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_engulfing(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
                             float *host_output, int size) {
-  Engulfing ind;
+  tacuda::Engulfing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2078,7 +2078,7 @@ ctStatus_t ct_cdl_evening_doji_star(const float *host_open,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
                                     int size) {
-  EveningDojiStar ind;
+  tacuda::EveningDojiStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2086,7 +2086,7 @@ ctStatus_t ct_cdl_evening_doji_star(const float *host_open,
 ctStatus_t ct_cdl_evening_star(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size) {
-  EveningStar ind;
+  tacuda::EveningStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2096,7 +2096,7 @@ ctStatus_t ct_cdl_gap_side_side_white(const float *host_open,
                                       const float *host_low,
                                       const float *host_close,
                                       float *host_output, int size) {
-  GapSideSideWhite ind;
+  tacuda::GapSideSideWhite ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2105,7 +2105,7 @@ ctStatus_t ct_cdl_gravestone_doji(const float *host_open,
                                   const float *host_high, const float *host_low,
                                   const float *host_close, float *host_output,
                                   int size) {
-  GravestoneDoji ind;
+  tacuda::GravestoneDoji ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2113,7 +2113,7 @@ ctStatus_t ct_cdl_gravestone_doji(const float *host_open,
 ctStatus_t ct_cdl_hanging_man(const float *host_open, const float *host_high,
                               const float *host_low, const float *host_close,
                               float *host_output, int size) {
-  HangingMan ind;
+  tacuda::HangingMan ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2121,7 +2121,7 @@ ctStatus_t ct_cdl_hanging_man(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_harami(const float *host_open, const float *host_high,
                          const float *host_low, const float *host_close,
                          float *host_output, int size) {
-  Harami ind;
+  tacuda::Harami ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2129,7 +2129,7 @@ ctStatus_t ct_cdl_harami(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_harami_cross(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size) {
-  HaramiCross ind;
+  tacuda::HaramiCross ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2137,7 +2137,7 @@ ctStatus_t ct_cdl_harami_cross(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_high_wave(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
                             float *host_output, int size) {
-  HighWave ind;
+  tacuda::HighWave ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2145,7 +2145,7 @@ ctStatus_t ct_cdl_high_wave(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_hikkake(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
                           float *host_output, int size) {
-  Hikkake ind;
+  tacuda::Hikkake ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2153,7 +2153,7 @@ ctStatus_t ct_cdl_hikkake(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_hikkake_mod(const float *host_open, const float *host_high,
                               const float *host_low, const float *host_close,
                               float *host_output, int size) {
-  HikkakeMod ind;
+  tacuda::HikkakeMod ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2161,7 +2161,7 @@ ctStatus_t ct_cdl_hikkake_mod(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_homing_pigeon(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
                                 float *host_output, int size) {
-  HomingPigeon ind;
+  tacuda::HomingPigeon ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2171,7 +2171,7 @@ ctStatus_t ct_cdl_identical_three_crows(const float *host_open,
                                         const float *host_low,
                                         const float *host_close,
                                         float *host_output, int size) {
-  IdenticalThreeCrows ind;
+  tacuda::IdenticalThreeCrows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2179,7 +2179,7 @@ ctStatus_t ct_cdl_identical_three_crows(const float *host_open,
 ctStatus_t ct_cdl_in_neck(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
                           float *host_output, int size) {
-  InNeck ind;
+  tacuda::InNeck ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2187,7 +2187,7 @@ ctStatus_t ct_cdl_in_neck(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_kicking(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
                           float *host_output, int size) {
-  Kicking ind;
+  tacuda::Kicking ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2197,7 +2197,7 @@ ctStatus_t ct_cdl_kicking_by_length(const float *host_open,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
                                     int size) {
-  KickingByLength ind;
+  tacuda::KickingByLength ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2205,7 +2205,7 @@ ctStatus_t ct_cdl_kicking_by_length(const float *host_open,
 ctStatus_t ct_cdl_ladder_bottom(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
                                 float *host_output, int size) {
-  LadderBottom ind;
+  tacuda::LadderBottom ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2215,7 +2215,7 @@ ctStatus_t ct_cdl_long_legged_doji(const float *host_open,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
                                    int size) {
-  LongLeggedDoji ind;
+  tacuda::LongLeggedDoji ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2223,7 +2223,7 @@ ctStatus_t ct_cdl_long_legged_doji(const float *host_open,
 ctStatus_t ct_cdl_long_line(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
                             float *host_output, int size) {
-  LongLine ind;
+  tacuda::LongLine ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2231,7 +2231,7 @@ ctStatus_t ct_cdl_long_line(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_marubozu(const float *host_open, const float *host_high,
                            const float *host_low, const float *host_close,
                            float *host_output, int size) {
-  Marubozu ind;
+  tacuda::Marubozu ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2239,7 +2239,7 @@ ctStatus_t ct_cdl_marubozu(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_matching_low(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size) {
-  MatchingLow ind;
+  tacuda::MatchingLow ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2247,7 +2247,7 @@ ctStatus_t ct_cdl_matching_low(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_mat_hold(const float *host_open, const float *host_high,
                            const float *host_low, const float *host_close,
                            float *host_output, int size) {
-  MatHold ind;
+  tacuda::MatHold ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2257,7 +2257,7 @@ ctStatus_t ct_cdl_morning_doji_star(const float *host_open,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
                                     int size) {
-  MorningDojiStar ind;
+  tacuda::MorningDojiStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2265,7 +2265,7 @@ ctStatus_t ct_cdl_morning_doji_star(const float *host_open,
 ctStatus_t ct_cdl_morning_star(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size) {
-  MorningStar ind;
+  tacuda::MorningStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2273,7 +2273,7 @@ ctStatus_t ct_cdl_morning_star(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_on_neck(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
                           float *host_output, int size) {
-  OnNeck ind;
+  tacuda::OnNeck ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2281,7 +2281,7 @@ ctStatus_t ct_cdl_on_neck(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_piercing(const float *host_open, const float *host_high,
                            const float *host_low, const float *host_close,
                            float *host_output, int size) {
-  Piercing ind;
+  tacuda::Piercing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2289,7 +2289,7 @@ ctStatus_t ct_cdl_piercing(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_rickshaw_man(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size) {
-  RickshawMan ind;
+  tacuda::RickshawMan ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2299,7 +2299,7 @@ ctStatus_t ct_cdl_rise_fall3_methods(const float *host_open,
                                      const float *host_low,
                                      const float *host_close,
                                      float *host_output, int size) {
-  RiseFall3Methods ind;
+  tacuda::RiseFall3Methods ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2309,7 +2309,7 @@ ctStatus_t ct_cdl_separating_lines(const float *host_open,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
                                    int size) {
-  SeparatingLines ind;
+  tacuda::SeparatingLines ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2317,7 +2317,7 @@ ctStatus_t ct_cdl_separating_lines(const float *host_open,
 ctStatus_t ct_cdl_shooting_star(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
                                 float *host_output, int size) {
-  ShootingStar ind;
+  tacuda::ShootingStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2325,7 +2325,7 @@ ctStatus_t ct_cdl_shooting_star(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_short_line(const float *host_open, const float *host_high,
                              const float *host_low, const float *host_close,
                              float *host_output, int size) {
-  ShortLine ind;
+  tacuda::ShortLine ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2333,7 +2333,7 @@ ctStatus_t ct_cdl_short_line(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_spinning_top(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
                                float *host_output, int size) {
-  SpinningTop ind;
+  tacuda::SpinningTop ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2342,7 +2342,7 @@ ctStatus_t ct_cdl_stalled_pattern(const float *host_open,
                                   const float *host_high, const float *host_low,
                                   const float *host_close, float *host_output,
                                   int size) {
-  StalledPattern ind;
+  tacuda::StalledPattern ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2350,7 +2350,7 @@ ctStatus_t ct_cdl_stalled_pattern(const float *host_open,
 ctStatus_t ct_cdl_stick_sandwich(const float *host_open, const float *host_high,
                                  const float *host_low, const float *host_close,
                                  float *host_output, int size) {
-  StickSandwich ind;
+  tacuda::StickSandwich ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2358,7 +2358,7 @@ ctStatus_t ct_cdl_stick_sandwich(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_takuri(const float *host_open, const float *host_high,
                          const float *host_low, const float *host_close,
                          float *host_output, int size) {
-  Takuri ind;
+  tacuda::Takuri ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2366,7 +2366,7 @@ ctStatus_t ct_cdl_takuri(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_tasuki_gap(const float *host_open, const float *host_high,
                              const float *host_low, const float *host_close,
                              float *host_output, int size) {
-  TasukiGap ind;
+  tacuda::TasukiGap ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2374,7 +2374,7 @@ ctStatus_t ct_cdl_tasuki_gap(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_thrusting(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
                             float *host_output, int size) {
-  Thrusting ind;
+  tacuda::Thrusting ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2382,7 +2382,7 @@ ctStatus_t ct_cdl_thrusting(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_tristar(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
                           float *host_output, int size) {
-  Tristar ind;
+  tacuda::Tristar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2390,7 +2390,7 @@ ctStatus_t ct_cdl_tristar(const float *host_open, const float *host_high,
 ctStatus_t ct_cdl_unique_3_river(const float *host_open, const float *host_high,
                                  const float *host_low, const float *host_close,
                                  float *host_output, int size) {
-  Unique3River ind;
+  tacuda::Unique3River ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2400,7 +2400,7 @@ ctStatus_t ct_cdl_upside_gap_2_crows(const float *host_open,
                                      const float *host_low,
                                      const float *host_close,
                                      float *host_output, int size) {
-  UpsideGap2Crows ind;
+  tacuda::UpsideGap2Crows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
@@ -2410,20 +2410,20 @@ ctStatus_t ct_cdl_xside_gap_3_methods(const float *host_open,
                                       const float *host_low,
                                       const float *host_close,
                                       float *host_output, int size) {
-  XSideGap3Methods ind;
+  tacuda::XSideGap3Methods ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
                             host_output, size);
 }
 
 ctStatus_t ct_cmo(const float *host_input, float *host_output, int size,
                   int period) {
-  CMO cmo(period);
+  tacuda::CMO cmo(period);
   return run_indicator(cmo, host_input, host_output, size);
 }
 
 ctStatus_t ct_correl(const float *host_x, const float *host_y,
                      float *host_output, int size, int period) {
-  Correl correl(period);
+  tacuda::Correl correl(period);
   DeviceBuffer d_x{nullptr}, d_y{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
 
@@ -2474,7 +2474,7 @@ ctStatus_t ct_correl(const float *host_x, const float *host_y,
 ctStatus_t ct_dx(const float *host_high, const float *host_low,
                  const float *host_close, float *host_output, int size,
                  int period, cudaStream_t stream) {
-  DX dx(period);
+  tacuda::DX dx(period);
   return run_ohlc_indicator(dx, host_high, host_low, host_close, host_output,
                             size, 1, stream);
 }

--- a/src/indicators/AD.cu
+++ b/src/indicators/AD.cu
@@ -23,7 +23,7 @@ __global__ void adKernel(const float* __restrict__ high,
     }
 }
 
-void AD::calculate(const float* high, const float* low, const float* close,
+void tacuda::AD::calculate(const float* high, const float* low, const float* close,
                    const float* volume, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (size <= 0) {
         throw std::invalid_argument("AD: invalid size");
@@ -32,7 +32,7 @@ void AD::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void AD::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::AD::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/ADOSC.cu
+++ b/src/indicators/ADOSC.cu
@@ -51,10 +51,10 @@ __global__ void adoscKernel(const float* __restrict__ ad,
     }
 }
 
-ADOSC::ADOSC(int shortPeriod, int longPeriod)
+tacuda::ADOSC::ADOSC(int shortPeriod, int longPeriod)
     : shortPeriod(shortPeriod), longPeriod(longPeriod) {}
 
-void ADOSC::calculate(const float* high, const float* low, const float* close,
+void tacuda::ADOSC::calculate(const float* high, const float* low, const float* close,
                       const float* volume, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (shortPeriod <= 0 || longPeriod <= 0) {
         throw std::invalid_argument("ADOSC: invalid periods");
@@ -73,7 +73,7 @@ void ADOSC::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ADOSC::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ADOSC::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/ADX.cu
+++ b/src/indicators/ADX.cu
@@ -68,9 +68,9 @@ __global__ void adxKernel(const float* __restrict__ high,
     output[idx] = adx;
 }
 
-ADX::ADX(int period) : period(period) {}
+tacuda::ADX::ADX(int period) : period(period) {}
 
-void ADX::calculate(const float* high, const float* low, const float* close,
+void tacuda::ADX::calculate(const float* high, const float* low, const float* close,
                     float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("ADX: invalid period");
@@ -82,7 +82,7 @@ void ADX::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ADX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ADX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/ADXR.cu
+++ b/src/indicators/ADXR.cu
@@ -14,16 +14,16 @@ __global__ void adxrKernel(const float* __restrict__ adx,
     }
 }
 
-ADXR::ADXR(int period) : period(period) {}
+tacuda::ADXR::ADXR(int period) : period(period) {}
 
-void ADXR::calculate(const float* high, const float* low, const float* close,
+void tacuda::ADXR::calculate(const float* high, const float* low, const float* close,
                      float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("ADXR: invalid period");
     }
     auto adx = acquireDeviceBuffer<float>(size);
 
-    ADX adxInd(period);
+    tacuda::ADX adxInd(period);
     adxInd.calculate(high, low, close, adx.get(), size, stream);
 
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -33,7 +33,7 @@ void ADXR::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ADXR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ADXR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/APO.cu
+++ b/src/indicators/APO.cu
@@ -29,10 +29,10 @@ __global__ void apoKernel(const float* __restrict__ input,
     }
 }
 
-APO::APO(int fastPeriod, int slowPeriod)
+tacuda::APO::APO(int fastPeriod, int slowPeriod)
     : fastPeriod(fastPeriod), slowPeriod(slowPeriod) {}
 
-void APO::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::APO::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (fastPeriod <= 0 || slowPeriod <= 0) {
         throw std::invalid_argument("APO: invalid periods");
     }

--- a/src/indicators/ATR.cu
+++ b/src/indicators/ATR.cu
@@ -41,9 +41,9 @@ __global__ void atrKernel(const float* __restrict__ high,
     }
 }
 
-ATR::ATR(int period, float initial) : period(period), initial(initial) {}
+tacuda::ATR::ATR(int period, float initial) : period(period), initial(initial) {}
 
-void ATR::calculate(const float* high, const float* low, const float* close,
+void tacuda::ATR::calculate(const float* high, const float* low, const float* close,
                     float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("ATR: invalid period");
@@ -53,7 +53,7 @@ void ATR::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ATR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ATR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/AbandonedBaby.cu
+++ b/src/indicators/AbandonedBaby.cu
@@ -17,7 +17,7 @@ __global__ void abandonedBabyKernel(const float* __restrict__ open,
     }
 }
 
-void AbandonedBaby::calculate(const float* open, const float* high, const float* low,
+void tacuda::AbandonedBaby::calculate(const float* open, const float* high, const float* low,
                               const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -26,7 +26,7 @@ void AbandonedBaby::calculate(const float* open, const float* high, const float*
     CUDA_CHECK(cudaGetLastError());
 }
 
-void AbandonedBaby::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::AbandonedBaby::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/AdvanceBlock.cu
+++ b/src/indicators/AdvanceBlock.cu
@@ -17,7 +17,7 @@ __global__ void advanceBlockKernel(const float* __restrict__ open,
     }
 }
 
-void AdvanceBlock::calculate(const float* open, const float* high, const float* low,
+void tacuda::AdvanceBlock::calculate(const float* open, const float* high, const float* low,
                              const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -26,7 +26,7 @@ void AdvanceBlock::calculate(const float* open, const float* high, const float* 
     CUDA_CHECK(cudaGetLastError());
 }
 
-void AdvanceBlock::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::AdvanceBlock::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/Aroon.cu
+++ b/src/indicators/Aroon.cu
@@ -50,9 +50,9 @@ __global__ void aroonKernel(const float* __restrict__ high,
     }
 }
 
-Aroon::Aroon(int upPeriod, int downPeriod) : upPeriod(upPeriod), downPeriod(downPeriod) {}
+tacuda::Aroon::Aroon(int upPeriod, int downPeriod) : upPeriod(upPeriod), downPeriod(downPeriod) {}
 
-void Aroon::calculate(const float* high, const float* low, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Aroon::calculate(const float* high, const float* low, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (upPeriod <= 0 || upPeriod > size || downPeriod <= 0 || downPeriod > size) {
         throw std::invalid_argument("Aroon: invalid period");
     }
@@ -61,7 +61,7 @@ void Aroon::calculate(const float* high, const float* low, float* output, int si
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Aroon::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Aroon::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     calculate(high, low, output, size, stream);

--- a/src/indicators/AroonOscillator.cu
+++ b/src/indicators/AroonOscillator.cu
@@ -34,9 +34,9 @@ __global__ void aroonOscKernel(const float* __restrict__ high,
     }
 }
 
-AroonOscillator::AroonOscillator(int period) : period(period) {}
+tacuda::AroonOscillator::AroonOscillator(int period) : period(period) {}
 
-void AroonOscillator::calculate(const float* high, const float* low,
+void tacuda::AroonOscillator::calculate(const float* high, const float* low,
                                 float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("AroonOscillator: invalid period");
@@ -46,7 +46,7 @@ void AroonOscillator::calculate(const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void AroonOscillator::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::AroonOscillator::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     calculate(high, low, output, size, stream);

--- a/src/indicators/AvgPrice.cu
+++ b/src/indicators/AvgPrice.cu
@@ -14,7 +14,7 @@ __global__ void avgPriceKernel(const float* __restrict__ open,
     }
 }
 
-void AvgPrice::calculate(const float* open, const float* high, const float* low,
+void tacuda::AvgPrice::calculate(const float* open, const float* high, const float* low,
                          const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (size <= 0) {
         throw std::invalid_argument("AvgPrice: invalid size");
@@ -25,7 +25,7 @@ void AvgPrice::calculate(const float* open, const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void AvgPrice::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::AvgPrice::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/BBANDS.cu
+++ b/src/indicators/BBANDS.cu
@@ -39,10 +39,10 @@ __global__ void bbandsKernel(const float* __restrict__ prefix,
     }
 }
 
-BBANDS::BBANDS(int period, float upperMultiplier, float lowerMultiplier)
+tacuda::BBANDS::BBANDS(int period, float upperMultiplier, float lowerMultiplier)
     : period(period), upperMultiplier(upperMultiplier), lowerMultiplier(lowerMultiplier) {}
 
-void BBANDS::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::BBANDS::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("BBANDS: invalid period");
     }

--- a/src/indicators/BOP.cu
+++ b/src/indicators/BOP.cu
@@ -15,7 +15,7 @@ __global__ void bopKernel(const float* __restrict__ open,
     }
 }
 
-void BOP::calculate(const float* open, const float* high, const float* low,
+void tacuda::BOP::calculate(const float* open, const float* high, const float* low,
                     const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -24,7 +24,7 @@ void BOP::calculate(const float* open, const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void BOP::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::BOP::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/BearishEngulfing.cu
+++ b/src/indicators/BearishEngulfing.cu
@@ -15,7 +15,7 @@ __global__ void bearishEngulfingKernel(const float* __restrict__ open,
     }
 }
 
-void BearishEngulfing::calculate(const float* open, const float* high, const float* low,
+void tacuda::BearishEngulfing::calculate(const float* open, const float* high, const float* low,
                                  const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -24,7 +24,7 @@ void BearishEngulfing::calculate(const float* open, const float* high, const flo
     CUDA_CHECK(cudaGetLastError());
 }
 
-void BearishEngulfing::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::BearishEngulfing::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/BeltHold.cu
+++ b/src/indicators/BeltHold.cu
@@ -14,7 +14,7 @@ __global__ void beltHoldKernel(const float* __restrict__ open,
     }
 }
 
-void BeltHold::calculate(const float* open, const float* high, const float* low,
+void tacuda::BeltHold::calculate(const float* open, const float* high, const float* low,
                          const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -23,7 +23,7 @@ void BeltHold::calculate(const float* open, const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void BeltHold::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::BeltHold::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/Beta.cu
+++ b/src/indicators/Beta.cu
@@ -27,9 +27,9 @@ __global__ void betaKernel(const float* __restrict__ x,
     }
 }
 
-Beta::Beta(int period) : period(period) {}
+tacuda::Beta::Beta(int period) : period(period) {}
 
-void Beta::calculate(const float* x, const float* y, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Beta::calculate(const float* x, const float* y, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("Beta: invalid period");
     }
@@ -40,7 +40,7 @@ void Beta::calculate(const float* x, const float* y, float* output, int size, cu
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Beta::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Beta::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* x = input;
     const float* y = input + size;
     calculate(x, y, output, size, stream);

--- a/src/indicators/Breakaway.cu
+++ b/src/indicators/Breakaway.cu
@@ -19,7 +19,7 @@ __global__ void breakawayKernel(const float* __restrict__ open,
     }
 }
 
-void Breakaway::calculate(const float* open, const float* high, const float* low,
+void tacuda::Breakaway::calculate(const float* open, const float* high, const float* low,
                           const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -28,7 +28,7 @@ void Breakaway::calculate(const float* open, const float* high, const float* low
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Breakaway::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Breakaway::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/BullishEngulfing.cu
+++ b/src/indicators/BullishEngulfing.cu
@@ -15,7 +15,7 @@ __global__ void bullishEngulfingKernel(const float* __restrict__ open,
     }
 }
 
-void BullishEngulfing::calculate(const float* open, const float* high, const float* low,
+void tacuda::BullishEngulfing::calculate(const float* open, const float* high, const float* low,
                                  const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -24,7 +24,7 @@ void BullishEngulfing::calculate(const float* open, const float* high, const flo
     CUDA_CHECK(cudaGetLastError());
 }
 
-void BullishEngulfing::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::BullishEngulfing::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/CCI.cu
+++ b/src/indicators/CCI.cu
@@ -28,9 +28,9 @@ __global__ void cciKernel(const float* __restrict__ high,
     }
 }
 
-CCI::CCI(int period) : period(period) {}
+tacuda::CCI::CCI(int period) : period(period) {}
 
-void CCI::calculate(const float* high, const float* low, const float* close,
+void tacuda::CCI::calculate(const float* high, const float* low, const float* close,
                     float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("CCI: invalid period");
@@ -42,7 +42,7 @@ void CCI::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void CCI::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::CCI::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/CMO.cu
+++ b/src/indicators/CMO.cu
@@ -21,9 +21,9 @@ __global__ void cmoKernel(const float* __restrict__ input,
     }
 }
 
-CMO::CMO(int period) : period(period) {}
+tacuda::CMO::CMO(int period) : period(period) {}
 
-void CMO::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::CMO::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("CMO: invalid period");
     }

--- a/src/indicators/Change.cu
+++ b/src/indicators/Change.cu
@@ -10,9 +10,9 @@ __global__ void changeKernel(const float* __restrict__ input, float* __restrict_
     }
 }
 
-Change::Change(int period) : period(period) {}
+tacuda::Change::Change(int period) : period(period) {}
 
-void Change::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Change::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("Change: invalid period");
     }

--- a/src/indicators/ClosingMarubozu.cu
+++ b/src/indicators/ClosingMarubozu.cu
@@ -15,7 +15,7 @@ __global__ void closingMarubozuKernel(const float *__restrict__ open,
   }
 }
 
-void ClosingMarubozu::calculate(const float *open, const float *high,
+void tacuda::ClosingMarubozu::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -25,7 +25,7 @@ void ClosingMarubozu::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void ClosingMarubozu::calculate(const float *input, float *output,
+void tacuda::ClosingMarubozu::calculate(const float *input, float *output,
                                 int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/ConcealBabySwallow.cu
+++ b/src/indicators/ConcealBabySwallow.cu
@@ -20,7 +20,7 @@ __global__ void concealBabySwallowKernel(const float *__restrict__ open,
   }
 }
 
-void ConcealBabySwallow::calculate(const float *open, const float *high,
+void tacuda::ConcealBabySwallow::calculate(const float *open, const float *high,
                                    const float *low, const float *close,
                                    float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -31,7 +31,7 @@ void ConcealBabySwallow::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void ConcealBabySwallow::calculate(const float *input, float *output,
+void tacuda::ConcealBabySwallow::calculate(const float *input, float *output,
                                    int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/Correl.cu
+++ b/src/indicators/Correl.cu
@@ -29,9 +29,9 @@ __global__ void correlKernel(const float* __restrict__ x,
     }
 }
 
-Correl::Correl(int period) : period(period) {}
+tacuda::Correl::Correl(int period) : period(period) {}
 
-void Correl::calculate(const float* x, const float* y, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Correl::calculate(const float* x, const float* y, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("Correl: invalid period");
     }
@@ -42,7 +42,7 @@ void Correl::calculate(const float* x, const float* y, float* output, int size, 
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Correl::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Correl::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* x = input;
     const float* y = input + size;
     calculate(x, y, output, size, stream);

--- a/src/indicators/CounterAttack.cu
+++ b/src/indicators/CounterAttack.cu
@@ -17,7 +17,7 @@ __global__ void counterAttackKernel(const float *__restrict__ open,
   }
 }
 
-void CounterAttack::calculate(const float *open, const float *high,
+void tacuda::CounterAttack::calculate(const float *open, const float *high,
                               const float *low, const float *close,
                               float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void CounterAttack::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void CounterAttack::calculate(const float *input, float *output,
+void tacuda::CounterAttack::calculate(const float *input, float *output,
                               int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/DEMA.cu
+++ b/src/indicators/DEMA.cu
@@ -15,9 +15,9 @@ __global__ void demaKernel(const float* __restrict__ ema1,
     }
 }
 
-DEMA::DEMA(int period) : period(period) {}
+tacuda::DEMA::DEMA(int period) : period(period) {}
 
-void DEMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::DEMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || size < 2 * period - 1) {
         throw std::invalid_argument("DEMA: invalid period");
     }
@@ -27,7 +27,7 @@ void DEMA::calculate(const float* input, float* output, int size, cudaStream_t s
     auto ema1 = acquireDeviceBuffer<float>(size);
     auto ema2 = acquireDeviceBuffer<float>(size);
 
-    EMA ema(period);
+    tacuda::EMA ema(period);
     ema.calculate(input, ema1.get(), size, stream);
     int size2 = size - period + 1;
     ema.calculate(ema1.get(), ema2.get(), size2);

--- a/src/indicators/DX.cu
+++ b/src/indicators/DX.cu
@@ -38,9 +38,9 @@ __global__ void dxKernel(const float* __restrict__ high,
     }
 }
 
-DX::DX(int period) : period(period) {}
+tacuda::DX::DX(int period) : period(period) {}
 
-void DX::calculate(const float* high, const float* low, const float* close,
+void tacuda::DX::calculate(const float* high, const float* low, const float* close,
                    float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("DX: invalid period");
@@ -52,7 +52,7 @@ void DX::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void DX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::DX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/DarkCloudCover.cu
+++ b/src/indicators/DarkCloudCover.cu
@@ -17,7 +17,7 @@ __global__ void darkCloudCoverKernel(const float *__restrict__ open,
   }
 }
 
-void DarkCloudCover::calculate(const float *open, const float *high,
+void tacuda::DarkCloudCover::calculate(const float *open, const float *high,
                                const float *low, const float *close,
                                float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void DarkCloudCover::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void DarkCloudCover::calculate(const float *input, float *output,
+void tacuda::DarkCloudCover::calculate(const float *input, float *output,
                                int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/Doji.cu
+++ b/src/indicators/Doji.cu
@@ -14,9 +14,9 @@ __global__ void dojiKernel(const float* __restrict__ open,
     }
 }
 
-Doji::Doji(float threshold) : threshold(threshold) {}
+tacuda::Doji::Doji(float threshold) : threshold(threshold) {}
 
-void Doji::calculate(const float* open, const float* high, const float* low,
+void tacuda::Doji::calculate(const float* open, const float* high, const float* low,
                      const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -25,7 +25,7 @@ void Doji::calculate(const float* open, const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Doji::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Doji::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/DojiStar.cu
+++ b/src/indicators/DojiStar.cu
@@ -17,7 +17,7 @@ __global__ void dojiStarKernel(const float *__restrict__ open,
   }
 }
 
-void DojiStar::calculate(const float *open, const float *high, const float *low,
+void tacuda::DojiStar::calculate(const float *open, const float *high, const float *low,
                          const float *close, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void DojiStar::calculate(const float *open, const float *high, const float *low,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void DojiStar::calculate(const float *input, float *output,
+void tacuda::DojiStar::calculate(const float *input, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/DragonflyDoji.cu
+++ b/src/indicators/DragonflyDoji.cu
@@ -15,7 +15,7 @@ __global__ void dragonflyDojiKernel(const float *__restrict__ open,
   }
 }
 
-void DragonflyDoji::calculate(const float *open, const float *high,
+void tacuda::DragonflyDoji::calculate(const float *open, const float *high,
                               const float *low, const float *close,
                               float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -25,7 +25,7 @@ void DragonflyDoji::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void DragonflyDoji::calculate(const float *input, float *output,
+void tacuda::DragonflyDoji::calculate(const float *input, float *output,
                               int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/EMA.cu
+++ b/src/indicators/EMA.cu
@@ -20,9 +20,9 @@ __global__ void emaKernel(const float* __restrict__ input,
     }
 }
 
-EMA::EMA(int period) : period(period) {}
+tacuda::EMA::EMA(int period) : period(period) {}
 
-void EMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::EMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("EMA: invalid period");
     }

--- a/src/indicators/Engulfing.cu
+++ b/src/indicators/Engulfing.cu
@@ -14,7 +14,7 @@ __global__ void engulfingKernel(const float *__restrict__ open,
   }
 }
 
-void Engulfing::calculate(const float *open, const float *high,
+void tacuda::Engulfing::calculate(const float *open, const float *high,
                           const float *low, const float *close, float *output,
                           int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -24,7 +24,7 @@ void Engulfing::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void Engulfing::calculate(const float *input, float *output,
+void tacuda::Engulfing::calculate(const float *input, float *output,
                           int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/EveningDojiStar.cu
+++ b/src/indicators/EveningDojiStar.cu
@@ -19,7 +19,7 @@ __global__ void eveningDojiStarKernel(const float *__restrict__ open,
   }
 }
 
-void EveningDojiStar::calculate(const float *open, const float *high,
+void tacuda::EveningDojiStar::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -29,7 +29,7 @@ void EveningDojiStar::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void EveningDojiStar::calculate(const float *input, float *output,
+void tacuda::EveningDojiStar::calculate(const float *input, float *output,
                                 int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/EveningStar.cu
+++ b/src/indicators/EveningStar.cu
@@ -18,7 +18,7 @@ __global__ void eveningStarKernel(const float *__restrict__ open,
   }
 }
 
-void EveningStar::calculate(const float *open, const float *high,
+void tacuda::EveningStar::calculate(const float *open, const float *high,
                             const float *low, const float *close, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -28,7 +28,7 @@ void EveningStar::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void EveningStar::calculate(const float *input, float *output,
+void tacuda::EveningStar::calculate(const float *input, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/GapSideSideWhite.cu
+++ b/src/indicators/GapSideSideWhite.cu
@@ -17,7 +17,7 @@ __global__ void gapSideSideWhiteKernel(const float* __restrict__ open,
     }
 }
 
-void GapSideSideWhite::calculate(const float* open, const float* high,
+void tacuda::GapSideSideWhite::calculate(const float* open, const float* high,
                                  const float* low, const float* close,
                                  float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void GapSideSideWhite::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void GapSideSideWhite::calculate(const float* input, float* output,
+void tacuda::GapSideSideWhite::calculate(const float* input, float* output,
                                  int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/GravestoneDoji.cu
+++ b/src/indicators/GravestoneDoji.cu
@@ -16,7 +16,7 @@ __global__ void gravestoneDojiKernel(const float* __restrict__ open,
     }
 }
 
-void GravestoneDoji::calculate(const float* open, const float* high,
+void tacuda::GravestoneDoji::calculate(const float* open, const float* high,
                                const float* low, const float* close,
                                float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -26,7 +26,7 @@ void GravestoneDoji::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void GravestoneDoji::calculate(const float* input, float* output,
+void tacuda::GravestoneDoji::calculate(const float* input, float* output,
                                int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/HT_DCPERIOD.cu
+++ b/src/indicators/HT_DCPERIOD.cu
@@ -209,7 +209,7 @@ static void ht_dcperiod_cpu(const std::vector<float>& in, std::vector<float>& ou
     }
 }
 
-void HT_DCPERIOD::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::HT_DCPERIOD::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     std::vector<float> h_in(size);
     CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
     std::vector<float> h_out(size, std::numeric_limits<float>::quiet_NaN());

--- a/src/indicators/HT_DCPHASE.cu
+++ b/src/indicators/HT_DCPHASE.cu
@@ -249,7 +249,7 @@ static void ht_dcphase_cpu(const std::vector<float>& in, std::vector<float>& out
     }
 }
 
-void HT_DCPHASE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::HT_DCPHASE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     std::vector<float> h_in(size);
     CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
     std::vector<float> h_out(size, std::numeric_limits<float>::quiet_NaN());

--- a/src/indicators/HT_PHASOR.cu
+++ b/src/indicators/HT_PHASOR.cu
@@ -217,7 +217,7 @@ static void ht_phasor_cpu(const std::vector<float>& in,
     }
 }
 
-void HT_PHASOR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::HT_PHASOR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     std::vector<float> h_in(size);
     CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
     std::vector<float> inphase(size, std::numeric_limits<float>::quiet_NaN());

--- a/src/indicators/HT_SINE.cu
+++ b/src/indicators/HT_SINE.cu
@@ -255,7 +255,7 @@ static void ht_sine_cpu(const std::vector<float>& in,
     }
 }
 
-void HT_SINE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::HT_SINE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     std::vector<float> h_in(size);
     CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
     std::vector<float> sine(size, std::numeric_limits<float>::quiet_NaN());

--- a/src/indicators/HT_TRENDLINE.cu
+++ b/src/indicators/HT_TRENDLINE.cu
@@ -220,7 +220,7 @@ static void ht_trendline_cpu(const std::vector<float>& in, std::vector<float>& o
     }
 }
 
-void HT_TRENDLINE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::HT_TRENDLINE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     std::vector<float> h_in(size);
     CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
     std::vector<float> h_out(size, std::numeric_limits<float>::quiet_NaN());

--- a/src/indicators/HT_TRENDMODE.cu
+++ b/src/indicators/HT_TRENDMODE.cu
@@ -292,7 +292,7 @@ static void ht_trendmode_cpu(const std::vector<float>& in, std::vector<int>& out
     }
 }
 
-void HT_TRENDMODE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::HT_TRENDMODE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     std::vector<float> h_in(size);
     CUDA_CHECK(cudaMemcpy(h_in.data(), input, size * sizeof(float), cudaMemcpyDeviceToHost));
     std::vector<int> h_out(size, 0);

--- a/src/indicators/Hammer.cu
+++ b/src/indicators/Hammer.cu
@@ -14,7 +14,7 @@ __global__ void hammerKernel(const float* __restrict__ open,
     }
 }
 
-void Hammer::calculate(const float* open, const float* high, const float* low,
+void tacuda::Hammer::calculate(const float* open, const float* high, const float* low,
                        const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -23,7 +23,7 @@ void Hammer::calculate(const float* open, const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Hammer::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Hammer::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/HangingMan.cu
+++ b/src/indicators/HangingMan.cu
@@ -16,7 +16,7 @@ __global__ void hangingManKernel(const float* __restrict__ open,
     }
 }
 
-void HangingMan::calculate(const float* open, const float* high,
+void tacuda::HangingMan::calculate(const float* open, const float* high,
                            const float* low, const float* close,
                            float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -26,7 +26,7 @@ void HangingMan::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void HangingMan::calculate(const float* input, float* output,
+void tacuda::HangingMan::calculate(const float* input, float* output,
                            int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/Harami.cu
+++ b/src/indicators/Harami.cu
@@ -14,7 +14,7 @@ __global__ void haramiKernel(const float* __restrict__ open,
     }
 }
 
-void Harami::calculate(const float* open, const float* high,
+void tacuda::Harami::calculate(const float* open, const float* high,
                        const float* low, const float* close,
                        float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -24,7 +24,7 @@ void Harami::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Harami::calculate(const float* input, float* output,
+void tacuda::Harami::calculate(const float* input, float* output,
                        int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/HaramiCross.cu
+++ b/src/indicators/HaramiCross.cu
@@ -16,7 +16,7 @@ __global__ void haramiCrossKernel(const float* __restrict__ open,
     }
 }
 
-void HaramiCross::calculate(const float* open, const float* high,
+void tacuda::HaramiCross::calculate(const float* open, const float* high,
                             const float* low, const float* close,
                             float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -26,7 +26,7 @@ void HaramiCross::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void HaramiCross::calculate(const float* input, float* output,
+void tacuda::HaramiCross::calculate(const float* input, float* output,
                             int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/HighWave.cu
+++ b/src/indicators/HighWave.cu
@@ -14,7 +14,7 @@ __global__ void highWaveKernel(const float* __restrict__ open,
     }
 }
 
-void HighWave::calculate(const float* open, const float* high,
+void tacuda::HighWave::calculate(const float* open, const float* high,
                          const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -24,7 +24,7 @@ void HighWave::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void HighWave::calculate(const float* input, float* output,
+void tacuda::HighWave::calculate(const float* input, float* output,
                          int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/Hikkake.cu
+++ b/src/indicators/Hikkake.cu
@@ -16,7 +16,7 @@ __global__ void hikkakeKernel(const float* __restrict__ open,
     }
 }
 
-void Hikkake::calculate(const float* open, const float* high, const float* low,
+void tacuda::Hikkake::calculate(const float* open, const float* high, const float* low,
                         const float* close, float* output,
                         int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -26,7 +26,7 @@ void Hikkake::calculate(const float* open, const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Hikkake::calculate(const float* input, float* output,
+void tacuda::Hikkake::calculate(const float* input, float* output,
                         int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/HikkakeMod.cu
+++ b/src/indicators/HikkakeMod.cu
@@ -19,7 +19,7 @@ __global__ void hikkakeModKernel(const float* __restrict__ open,
     }
 }
 
-void HikkakeMod::calculate(const float* open, const float* high,
+void tacuda::HikkakeMod::calculate(const float* open, const float* high,
                            const float* low, const float* close,
                            float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -29,7 +29,7 @@ void HikkakeMod::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void HikkakeMod::calculate(const float* input, float* output,
+void tacuda::HikkakeMod::calculate(const float* input, float* output,
                            int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/HomingPigeon.cu
+++ b/src/indicators/HomingPigeon.cu
@@ -17,7 +17,7 @@ __global__ void homingPigeonKernel(const float* __restrict__ open,
     }
 }
 
-void HomingPigeon::calculate(const float* open, const float* high,
+void tacuda::HomingPigeon::calculate(const float* open, const float* high,
                              const float* low, const float* close,
                              float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void HomingPigeon::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void HomingPigeon::calculate(const float* input, float* output,
+void tacuda::HomingPigeon::calculate(const float* input, float* output,
                              int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/IdenticalThreeCrows.cu
+++ b/src/indicators/IdenticalThreeCrows.cu
@@ -20,7 +20,7 @@ __global__ void identicalThreeCrowsKernel(const float *__restrict__ open,
   }
 }
 
-void IdenticalThreeCrows::calculate(const float *open, const float *high,
+void tacuda::IdenticalThreeCrows::calculate(const float *open, const float *high,
                                     const float *low, const float *close,
                                     float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -31,7 +31,7 @@ void IdenticalThreeCrows::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void IdenticalThreeCrows::calculate(const float *input, float *output,
+void tacuda::IdenticalThreeCrows::calculate(const float *input, float *output,
                                     int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/InNeck.cu
+++ b/src/indicators/InNeck.cu
@@ -17,7 +17,7 @@ __global__ void inNeckKernel(const float *__restrict__ open,
   }
 }
 
-void InNeck::calculate(const float *open, const float *high, const float *low,
+void tacuda::InNeck::calculate(const float *open, const float *high, const float *low,
                        const float *close, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void InNeck::calculate(const float *open, const float *high, const float *low,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void InNeck::calculate(const float *input, float *output,
+void tacuda::InNeck::calculate(const float *input, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/InvertedHammer.cu
+++ b/src/indicators/InvertedHammer.cu
@@ -14,7 +14,7 @@ __global__ void invertedHammerKernel(const float* __restrict__ open,
     }
 }
 
-void InvertedHammer::calculate(const float* open, const float* high, const float* low,
+void tacuda::InvertedHammer::calculate(const float* open, const float* high, const float* low,
                                const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -23,7 +23,7 @@ void InvertedHammer::calculate(const float* open, const float* high, const float
     CUDA_CHECK(cudaGetLastError());
 }
 
-void InvertedHammer::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::InvertedHammer::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/KAMA.cu
+++ b/src/indicators/KAMA.cu
@@ -25,11 +25,11 @@ __global__ void kamaKernel(const float *__restrict__ input,
   }
 }
 
-KAMA::KAMA(int period, int fastPeriod, int slowPeriod)
+tacuda::KAMA::KAMA(int period, int fastPeriod, int slowPeriod)
     : period(period), fastSC(2.0f / (fastPeriod + 1.0f)),
       slowSC(2.0f / (slowPeriod + 1.0f)) {}
 
-void KAMA::calculate(const float *input, float *output,
+void tacuda::KAMA::calculate(const float *input, float *output,
                      int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("KAMA: invalid period");

--- a/src/indicators/Kicking.cu
+++ b/src/indicators/Kicking.cu
@@ -17,7 +17,7 @@ __global__ void kickingKernel(const float *__restrict__ open,
   }
 }
 
-void Kicking::calculate(const float *open, const float *high, const float *low,
+void tacuda::Kicking::calculate(const float *open, const float *high, const float *low,
                         const float *close, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void Kicking::calculate(const float *open, const float *high, const float *low,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void Kicking::calculate(const float *input, float *output,
+void tacuda::Kicking::calculate(const float *input, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/KickingByLength.cu
+++ b/src/indicators/KickingByLength.cu
@@ -17,7 +17,7 @@ __global__ void kickingByLengthKernel(const float *__restrict__ open,
   }
 }
 
-void KickingByLength::calculate(const float *open, const float *high,
+void tacuda::KickingByLength::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void KickingByLength::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void KickingByLength::calculate(const float *input, float *output,
+void tacuda::KickingByLength::calculate(const float *input, float *output,
                                 int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/LINEARREG.cu
+++ b/src/indicators/LINEARREG.cu
@@ -23,9 +23,9 @@ __global__ void linearregKernel(const float* __restrict__ in,
     }
 }
 
-LINEARREG::LINEARREG(int period) : period(period) {}
+tacuda::LINEARREG::LINEARREG(int period) : period(period) {}
 
-void LINEARREG::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::LINEARREG::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("LINEARREG: invalid period");
     }

--- a/src/indicators/LINEARREG_ANGLE.cu
+++ b/src/indicators/LINEARREG_ANGLE.cu
@@ -23,9 +23,9 @@ __global__ void linearregAngleKernel(const float* __restrict__ in,
     }
 }
 
-LINEARREG_ANGLE::LINEARREG_ANGLE(int period) : period(period) {}
+tacuda::LINEARREG_ANGLE::LINEARREG_ANGLE(int period) : period(period) {}
 
-void LINEARREG_ANGLE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::LINEARREG_ANGLE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("LINEARREG_ANGLE: invalid period");
     }

--- a/src/indicators/LINEARREG_INTERCEPT.cu
+++ b/src/indicators/LINEARREG_INTERCEPT.cu
@@ -23,9 +23,9 @@ __global__ void linearregInterceptKernel(const float* __restrict__ in,
     }
 }
 
-LINEARREG_INTERCEPT::LINEARREG_INTERCEPT(int period) : period(period) {}
+tacuda::LINEARREG_INTERCEPT::LINEARREG_INTERCEPT(int period) : period(period) {}
 
-void LINEARREG_INTERCEPT::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::LINEARREG_INTERCEPT::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("LINEARREG_INTERCEPT: invalid period");
     }

--- a/src/indicators/LINEARREG_SLOPE.cu
+++ b/src/indicators/LINEARREG_SLOPE.cu
@@ -22,9 +22,9 @@ __global__ void linearregSlopeKernel(const float* __restrict__ in,
     }
 }
 
-LINEARREG_SLOPE::LINEARREG_SLOPE(int period) : period(period) {}
+tacuda::LINEARREG_SLOPE::LINEARREG_SLOPE(int period) : period(period) {}
 
-void LINEARREG_SLOPE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::LINEARREG_SLOPE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("LINEARREG_SLOPE: invalid period");
     }

--- a/src/indicators/LadderBottom.cu
+++ b/src/indicators/LadderBottom.cu
@@ -20,7 +20,7 @@ __global__ void ladderBottomKernel(const float* __restrict__ open,
     }
 }
 
-void LadderBottom::calculate(const float* open, const float* high,
+void tacuda::LadderBottom::calculate(const float* open, const float* high,
                              const float* low, const float* close,
                              float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -30,7 +30,7 @@ void LadderBottom::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void LadderBottom::calculate(const float* input, float* output,
+void tacuda::LadderBottom::calculate(const float* input, float* output,
                              int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/LongLeggedDoji.cu
+++ b/src/indicators/LongLeggedDoji.cu
@@ -15,7 +15,7 @@ __global__ void longLeggedDojiKernel(const float* __restrict__ open,
     }
 }
 
-void LongLeggedDoji::calculate(const float* open, const float* high,
+void tacuda::LongLeggedDoji::calculate(const float* open, const float* high,
                                const float* low, const float* close,
                                float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -25,7 +25,7 @@ void LongLeggedDoji::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void LongLeggedDoji::calculate(const float* input, float* output,
+void tacuda::LongLeggedDoji::calculate(const float* input, float* output,
                                int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/LongLine.cu
+++ b/src/indicators/LongLine.cu
@@ -14,7 +14,7 @@ __global__ void longLineKernel(const float* __restrict__ open,
     }
 }
 
-void LongLine::calculate(const float* open, const float* high,
+void tacuda::LongLine::calculate(const float* open, const float* high,
                          const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -24,7 +24,7 @@ void LongLine::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void LongLine::calculate(const float* input, float* output,
+void tacuda::LongLine::calculate(const float* input, float* output,
                          int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/MA.cu
+++ b/src/indicators/MA.cu
@@ -3,20 +3,20 @@
 #include <indicators/EMA.h>
 #include <stdexcept>
 
-MA::MA(int period, MAType type) : period(period), type(type) {}
+tacuda::MA::MA(int period, tacuda::MAType type) : period(period), type(type) {}
 
-void MA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MA: invalid period");
     }
     switch (type) {
-    case MAType::SMA: {
-        SMA sma(period);
+    case tacuda::MAType::SMA: {
+        tacuda::SMA sma(period);
         sma.calculate(input, output, size, stream);
         break;
     }
-    case MAType::EMA: {
-        EMA ema(period);
+    case tacuda::MAType::EMA: {
+        tacuda::EMA ema(period);
         ema.calculate(input, output, size, stream);
         break;
     }

--- a/src/indicators/MACD.cu
+++ b/src/indicators/MACD.cu
@@ -68,10 +68,10 @@ __global__ void macdKernel(const float* __restrict__ emaFast,
     }
 }
 
-MACD::MACD(int fastPeriod, int slowPeriod)
+tacuda::MACD::MACD(int fastPeriod, int slowPeriod)
     : fastPeriod(fastPeriod), slowPeriod(slowPeriod) {}
 
-void MACD::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MACD::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (fastPeriod <= 0 || slowPeriod <= 0) {
         throw std::invalid_argument("MACD: invalid periods");
     }

--- a/src/indicators/MACDEXT.cu
+++ b/src/indicators/MACDEXT.cu
@@ -101,10 +101,10 @@ __global__ void histKernel(const float* __restrict__ macd,
     }
 }
 
-MACDEXT::MACDEXT(int fastPeriod, int slowPeriod, int signalPeriod, MAType type)
+tacuda::MACDEXT::MACDEXT(int fastPeriod, int slowPeriod, int signalPeriod, tacuda::MAType type)
     : fastPeriod(fastPeriod), slowPeriod(slowPeriod), signalPeriod(signalPeriod), type(type) {}
 
-void MACDEXT::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MACDEXT::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (fastPeriod <= 0 || slowPeriod <= 0 || signalPeriod <= 0) {
         throw std::invalid_argument("MACD: invalid periods");
     }
@@ -119,7 +119,7 @@ void MACDEXT::calculate(const float* input, float* output, int size, cudaStream_
     auto maFast = acquireDeviceBuffer<float>(size);
     auto maSlow = acquireDeviceBuffer<float>(size);
 
-    if (type == MAType::EMA) {
+    if (type == tacuda::MAType::EMA) {
         computeEma(input, maFast.get(), size, fastPeriod, stream);
         computeEma(input, maSlow.get(), size, slowPeriod, stream);
     } else {
@@ -132,7 +132,7 @@ void MACDEXT::calculate(const float* input, float* output, int size, cudaStream_
     macdLineKernel<<<grid, block, 0, stream>>>(maFast.get(), maSlow.get(), macd, slowPeriod, size);
     CUDA_CHECK(cudaGetLastError());
 
-    if (type == MAType::EMA) {
+    if (type == tacuda::MAType::EMA) {
         computeEma(macd + slowPeriod, signal + slowPeriod, size - slowPeriod, signalPeriod, stream);
     } else {
         computeSma(macd + slowPeriod, signal + slowPeriod, size - slowPeriod, signalPeriod, stream);

--- a/src/indicators/MACDFIX.cu
+++ b/src/indicators/MACDFIX.cu
@@ -1,10 +1,10 @@
 #include <indicators/MACDFIX.h>
 #include <indicators/MACDEXT.h>
 
-MACDFIX::MACDFIX(int signalPeriod) : signalPeriod(signalPeriod) {}
+tacuda::MACDFIX::MACDFIX(int signalPeriod) : signalPeriod(signalPeriod) {}
 
-void MACDFIX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
-    MACDEXT macd(12, 26, signalPeriod, MAType::EMA);
+void tacuda::MACDFIX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+    tacuda::MACDEXT macd(12, 26, signalPeriod, tacuda::MAType::EMA);
     macd.calculate(input, output, size, stream);
 }
 

--- a/src/indicators/MAMA.cu
+++ b/src/indicators/MAMA.cu
@@ -22,10 +22,10 @@ __global__ void mamaKernel(const float* __restrict__ input,
     }
 }
 
-MAMA::MAMA(float fastLimit, float slowLimit)
+tacuda::MAMA::MAMA(float fastLimit, float slowLimit)
     : fastLimit(fastLimit), slowLimit(slowLimit) {}
 
-void MAMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MAMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (size <= 0) {
         throw std::invalid_argument("MAMA: invalid size");
     }

--- a/src/indicators/MAX.cu
+++ b/src/indicators/MAX.cu
@@ -15,9 +15,9 @@ __global__ void maxKernel(const float* __restrict__ input,
     }
 }
 
-MAX::MAX(int period) : period(period) {}
+tacuda::MAX::MAX(int period) : period(period) {}
 
-void MAX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MAX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MAX: invalid period");
     }

--- a/src/indicators/MAXINDEX.cu
+++ b/src/indicators/MAXINDEX.cu
@@ -21,9 +21,9 @@ __global__ void maxIndexKernel(const float* __restrict__ input,
     }
 }
 
-MAXINDEX::MAXINDEX(int period) : period(period) {}
+tacuda::MAXINDEX::MAXINDEX(int period) : period(period) {}
 
-void MAXINDEX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MAXINDEX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MAXINDEX: invalid period");
     }

--- a/src/indicators/MFI.cu
+++ b/src/indicators/MFI.cu
@@ -50,9 +50,9 @@ __global__ void mfiKernel(const float* __restrict__ high,
     }
 }
 
-MFI::MFI(int period) : period(period) {}
+tacuda::MFI::MFI(int period) : period(period) {}
 
-void MFI::calculate(const float* high, const float* low, const float* close,
+void tacuda::MFI::calculate(const float* high, const float* low, const float* close,
                     const float* volume, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MFI: invalid period");
@@ -63,7 +63,7 @@ void MFI::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void MFI::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MFI::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/MIDPOINT.cu
+++ b/src/indicators/MIDPOINT.cu
@@ -19,9 +19,9 @@ __global__ void midpointKernel(const float* __restrict__ input,
     }
 }
 
-MIDPOINT::MIDPOINT(int period) : period(period) {}
+tacuda::MIDPOINT::MIDPOINT(int period) : period(period) {}
 
-void MIDPOINT::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MIDPOINT::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MIDPOINT: invalid period");
     }

--- a/src/indicators/MIDPRICE.cu
+++ b/src/indicators/MIDPRICE.cu
@@ -19,9 +19,9 @@ __global__ void midpriceKernel(const float* __restrict__ high,
     }
 }
 
-MIDPRICE::MIDPRICE(int period) : period(period) {}
+tacuda::MIDPRICE::MIDPRICE(int period) : period(period) {}
 
-void MIDPRICE::calculate(const float* high, const float* low, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MIDPRICE::calculate(const float* high, const float* low, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MIDPRICE: invalid period");
     }
@@ -32,7 +32,7 @@ void MIDPRICE::calculate(const float* high, const float* low, float* output, int
     CUDA_CHECK(cudaGetLastError());
 }
 
-void MIDPRICE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MIDPRICE::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     calculate(high, low, output, size, stream);

--- a/src/indicators/MIN.cu
+++ b/src/indicators/MIN.cu
@@ -15,9 +15,9 @@ __global__ void minKernel(const float* __restrict__ input,
     }
 }
 
-MIN::MIN(int period) : period(period) {}
+tacuda::MIN::MIN(int period) : period(period) {}
 
-void MIN::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MIN::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("MIN: invalid period");
     }

--- a/src/indicators/MININDEX.cu
+++ b/src/indicators/MININDEX.cu
@@ -21,9 +21,9 @@ __global__ void minIndexKernel(const float *__restrict__ input,
   }
 }
 
-MININDEX::MININDEX(int period) : period(period) {}
+tacuda::MININDEX::MININDEX(int period) : period(period) {}
 
-void MININDEX::calculate(const float *input, float *output,
+void tacuda::MININDEX::calculate(const float *input, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MININDEX: invalid period");

--- a/src/indicators/MINMAX.cu
+++ b/src/indicators/MINMAX.cu
@@ -20,9 +20,9 @@ __global__ void minmaxKernel(const float *__restrict__ input,
   }
 }
 
-MINMAX::MINMAX(int period) : period(period) {}
+tacuda::MINMAX::MINMAX(int period) : period(period) {}
 
-void MINMAX::calculate(const float *input, float *output,
+void tacuda::MINMAX::calculate(const float *input, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MINMAX: invalid period");

--- a/src/indicators/MINMAXINDEX.cu
+++ b/src/indicators/MINMAXINDEX.cu
@@ -29,9 +29,9 @@ __global__ void minmaxIndexKernel(const float *__restrict__ input,
   }
 }
 
-MINMAXINDEX::MINMAXINDEX(int period) : period(period) {}
+tacuda::MINMAXINDEX::MINMAXINDEX(int period) : period(period) {}
 
-void MINMAXINDEX::calculate(const float *input, float *output,
+void tacuda::MINMAXINDEX::calculate(const float *input, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MINMAXINDEX: invalid period");

--- a/src/indicators/Marubozu.cu
+++ b/src/indicators/Marubozu.cu
@@ -14,7 +14,7 @@ __global__ void marubozuKernel(const float* __restrict__ open,
     }
 }
 
-void Marubozu::calculate(const float* open, const float* high,
+void tacuda::Marubozu::calculate(const float* open, const float* high,
                          const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -24,7 +24,7 @@ void Marubozu::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Marubozu::calculate(const float* input, float* output,
+void tacuda::Marubozu::calculate(const float* input, float* output,
                          int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/MatHold.cu
+++ b/src/indicators/MatHold.cu
@@ -20,7 +20,7 @@ __global__ void matHoldKernel(const float *__restrict__ open,
   }
 }
 
-void MatHold::calculate(const float *open, const float *high, const float *low,
+void tacuda::MatHold::calculate(const float *open, const float *high, const float *low,
                         const float *close, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -30,7 +30,7 @@ void MatHold::calculate(const float *open, const float *high, const float *low,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void MatHold::calculate(const float *input, float *output,
+void tacuda::MatHold::calculate(const float *input, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/MatchingLow.cu
+++ b/src/indicators/MatchingLow.cu
@@ -17,7 +17,7 @@ __global__ void matchingLowKernel(const float* __restrict__ open,
     }
 }
 
-void MatchingLow::calculate(const float* open, const float* high,
+void tacuda::MatchingLow::calculate(const float* open, const float* high,
                              const float* low, const float* close,
                              float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void MatchingLow::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void MatchingLow::calculate(const float* input, float* output,
+void tacuda::MatchingLow::calculate(const float* input, float* output,
                              int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/MedPrice.cu
+++ b/src/indicators/MedPrice.cu
@@ -12,7 +12,7 @@ __global__ void medPriceKernel(const float* __restrict__ high,
     }
 }
 
-void MedPrice::calculate(const float* high, const float* low, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MedPrice::calculate(const float* high, const float* low, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (size <= 0) {
         throw std::invalid_argument("MedPrice: invalid size");
     }
@@ -22,7 +22,7 @@ void MedPrice::calculate(const float* high, const float* low, float* output, int
     CUDA_CHECK(cudaGetLastError());
 }
 
-void MedPrice::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::MedPrice::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     calculate(high, low, output, size, stream);

--- a/src/indicators/MinusDI.cu
+++ b/src/indicators/MinusDI.cu
@@ -37,9 +37,9 @@ __global__ void minusDIKernel(const float *__restrict__ high,
   }
 }
 
-MinusDI::MinusDI(int period) : period(period) {}
+tacuda::MinusDI::MinusDI(int period) : period(period) {}
 
-void MinusDI::calculate(const float *high, const float *low, const float *close,
+void tacuda::MinusDI::calculate(const float *high, const float *low, const float *close,
                         float *output, int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MinusDI: invalid period");
@@ -49,7 +49,7 @@ void MinusDI::calculate(const float *high, const float *low, const float *close,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void MinusDI::calculate(const float *input, float *output,
+void tacuda::MinusDI::calculate(const float *input, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
   const float *high = input;
   const float *low = input + size;

--- a/src/indicators/MinusDM.cu
+++ b/src/indicators/MinusDM.cu
@@ -34,9 +34,9 @@ __global__ void minusDMKernel(const float *__restrict__ high,
   }
 }
 
-MinusDM::MinusDM(int period) : period(period) {}
+tacuda::MinusDM::MinusDM(int period) : period(period) {}
 
-void MinusDM::calculate(const float *high, const float *low, float *output,
+void tacuda::MinusDM::calculate(const float *high, const float *low, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("MinusDM: invalid period");
@@ -46,7 +46,7 @@ void MinusDM::calculate(const float *high, const float *low, float *output,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void MinusDM::calculate(const float *input, float *output,
+void tacuda::MinusDM::calculate(const float *input, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
   const float *high = input;
   const float *low = input + size;

--- a/src/indicators/Momentum.cu
+++ b/src/indicators/Momentum.cu
@@ -10,9 +10,9 @@ __global__ void momentumKernel(const float* __restrict__ input, float* __restric
     }
 }
 
-Momentum::Momentum(int period) : period(period) {}
+tacuda::Momentum::Momentum(int period) : period(period) {}
 
-void Momentum::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Momentum::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("Momentum: invalid period");
     }

--- a/src/indicators/MorningDojiStar.cu
+++ b/src/indicators/MorningDojiStar.cu
@@ -19,7 +19,7 @@ __global__ void morningDojiStarKernel(const float *__restrict__ open,
   }
 }
 
-void MorningDojiStar::calculate(const float *open, const float *high,
+void tacuda::MorningDojiStar::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -29,7 +29,7 @@ void MorningDojiStar::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void MorningDojiStar::calculate(const float *input, float *output,
+void tacuda::MorningDojiStar::calculate(const float *input, float *output,
                                 int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/MorningStar.cu
+++ b/src/indicators/MorningStar.cu
@@ -18,7 +18,7 @@ __global__ void morningStarKernel(const float *__restrict__ open,
   }
 }
 
-void MorningStar::calculate(const float *open, const float *high,
+void tacuda::MorningStar::calculate(const float *open, const float *high,
                             const float *low, const float *close, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -28,7 +28,7 @@ void MorningStar::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void MorningStar::calculate(const float *input, float *output,
+void tacuda::MorningStar::calculate(const float *input, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/NATR.cu
+++ b/src/indicators/NATR.cu
@@ -32,9 +32,9 @@ __global__ void natrKernel(const float *__restrict__ high,
   }
 }
 
-NATR::NATR(int period) : period(period) {}
+tacuda::NATR::NATR(int period) : period(period) {}
 
-void NATR::calculate(const float *high, const float *low, const float *close,
+void tacuda::NATR::calculate(const float *high, const float *low, const float *close,
                      float *output, int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("NATR: invalid period");
@@ -44,7 +44,7 @@ void NATR::calculate(const float *high, const float *low, const float *close,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void NATR::calculate(const float *input, float *output,
+void tacuda::NATR::calculate(const float *input, float *output,
                      int size, cudaStream_t stream) noexcept(false) {
   const float *high = input;
   const float *low = input + size;

--- a/src/indicators/OBV.cu
+++ b/src/indicators/OBV.cu
@@ -25,7 +25,7 @@ __global__ void obvKernel(const float* __restrict__ price,
     }
 }
 
-void OBV::calculate(const float* price, const float* volume,
+void tacuda::OBV::calculate(const float* price, const float* volume,
                     float* output, int size, cudaStream_t stream) noexcept(false) {
     if (size <= 0) {
         throw std::invalid_argument("OBV: invalid size");
@@ -34,7 +34,7 @@ void OBV::calculate(const float* price, const float* volume,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void OBV::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::OBV::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* price = input;
     const float* volume = input + size;
     calculate(price, volume, output, size, stream);

--- a/src/indicators/OnNeck.cu
+++ b/src/indicators/OnNeck.cu
@@ -17,7 +17,7 @@ __global__ void onNeckKernel(const float *__restrict__ open,
   }
 }
 
-void OnNeck::calculate(const float *open, const float *high, const float *low,
+void tacuda::OnNeck::calculate(const float *open, const float *high, const float *low,
                        const float *close, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void OnNeck::calculate(const float *open, const float *high, const float *low,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void OnNeck::calculate(const float *input, float *output,
+void tacuda::OnNeck::calculate(const float *input, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/PPO.cu
+++ b/src/indicators/PPO.cu
@@ -29,10 +29,10 @@ __global__ void ppoKernel(const float* __restrict__ input,
   }
 }
 
-PPO::PPO(int fastPeriod, int slowPeriod)
+tacuda::PPO::PPO(int fastPeriod, int slowPeriod)
     : fastPeriod(fastPeriod), slowPeriod(slowPeriod) {}
 
-void PPO::calculate(const float* input, float* output,
+void tacuda::PPO::calculate(const float* input, float* output,
                     int size, cudaStream_t stream) noexcept(false) {
   if (fastPeriod <= 0 || slowPeriod <= 0) {
     throw std::invalid_argument("PPO: invalid periods");

--- a/src/indicators/PVO.cu
+++ b/src/indicators/PVO.cu
@@ -29,10 +29,10 @@ __global__ void pvoKernel(const float* __restrict__ input,
   }
 }
 
-PVO::PVO(int fastPeriod, int slowPeriod)
+tacuda::PVO::PVO(int fastPeriod, int slowPeriod)
     : fastPeriod(fastPeriod), slowPeriod(slowPeriod) {}
 
-void PVO::calculate(const float* input, float* output,
+void tacuda::PVO::calculate(const float* input, float* output,
                     int size, cudaStream_t stream) noexcept(false) {
   if (fastPeriod <= 0 || slowPeriod <= 0) {
     throw std::invalid_argument("PVO: invalid periods");

--- a/src/indicators/Piercing.cu
+++ b/src/indicators/Piercing.cu
@@ -17,7 +17,7 @@ __global__ void piercingKernel(const float *__restrict__ open,
   }
 }
 
-void Piercing::calculate(const float *open, const float *high, const float *low,
+void tacuda::Piercing::calculate(const float *open, const float *high, const float *low,
                          const float *close, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void Piercing::calculate(const float *open, const float *high, const float *low,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void Piercing::calculate(const float *input, float *output,
+void tacuda::Piercing::calculate(const float *input, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/PlusDI.cu
+++ b/src/indicators/PlusDI.cu
@@ -36,9 +36,9 @@ __global__ void plusDIKernel(const float *__restrict__ high,
   }
 }
 
-PlusDI::PlusDI(int period) : period(period) {}
+tacuda::PlusDI::PlusDI(int period) : period(period) {}
 
-void PlusDI::calculate(const float *high, const float *low, const float *close,
+void tacuda::PlusDI::calculate(const float *high, const float *low, const float *close,
                        float *output, int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("PlusDI: invalid period");
@@ -48,7 +48,7 @@ void PlusDI::calculate(const float *high, const float *low, const float *close,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void PlusDI::calculate(const float *input, float *output,
+void tacuda::PlusDI::calculate(const float *input, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   const float *high = input;
   const float *low = input + size;

--- a/src/indicators/PlusDM.cu
+++ b/src/indicators/PlusDM.cu
@@ -33,9 +33,9 @@ __global__ void plusDMKernel(const float *__restrict__ high,
   }
 }
 
-PlusDM::PlusDM(int period) : period(period) {}
+tacuda::PlusDM::PlusDM(int period) : period(period) {}
 
-void PlusDM::calculate(const float *high, const float *low, float *output,
+void tacuda::PlusDM::calculate(const float *high, const float *low, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("PlusDM: invalid period");
@@ -45,7 +45,7 @@ void PlusDM::calculate(const float *high, const float *low, float *output,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void PlusDM::calculate(const float *input, float *output,
+void tacuda::PlusDM::calculate(const float *input, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   const float *high = input;
   const float *low = input + size;

--- a/src/indicators/ROC.cu
+++ b/src/indicators/ROC.cu
@@ -12,9 +12,9 @@ __global__ void rocKernel(const float* __restrict__ input, float* __restrict__ o
     }
 }
 
-ROC::ROC(int period) : period(period) {}
+tacuda::ROC::ROC(int period) : period(period) {}
 
-void ROC::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ROC::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("ROC: invalid period");
     }

--- a/src/indicators/ROCP.cu
+++ b/src/indicators/ROCP.cu
@@ -12,9 +12,9 @@ __global__ void rocpKernel(const float *__restrict__ input,
   }
 }
 
-ROCP::ROCP(int period) : period(period) {}
+tacuda::ROCP::ROCP(int period) : period(period) {}
 
-void ROCP::calculate(const float *input, float *output,
+void tacuda::ROCP::calculate(const float *input, float *output,
                      int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period >= size) {
     throw std::invalid_argument("ROCP: invalid period");

--- a/src/indicators/ROCR.cu
+++ b/src/indicators/ROCR.cu
@@ -12,9 +12,9 @@ __global__ void rocrKernel(const float *__restrict__ input,
   }
 }
 
-ROCR::ROCR(int period) : period(period) {}
+tacuda::ROCR::ROCR(int period) : period(period) {}
 
-void ROCR::calculate(const float *input, float *output,
+void tacuda::ROCR::calculate(const float *input, float *output,
                      int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period >= size) {
     throw std::invalid_argument("ROCR: invalid period");

--- a/src/indicators/ROCR100.cu
+++ b/src/indicators/ROCR100.cu
@@ -13,9 +13,9 @@ __global__ void rocr100Kernel(const float *__restrict__ input,
   }
 }
 
-ROCR100::ROCR100(int period) : period(period) {}
+tacuda::ROCR100::ROCR100(int period) : period(period) {}
 
-void ROCR100::calculate(const float *input, float *output,
+void tacuda::ROCR100::calculate(const float *input, float *output,
                         int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period >= size) {
     throw std::invalid_argument("ROCR100: invalid period");

--- a/src/indicators/RSI.cu
+++ b/src/indicators/RSI.cu
@@ -41,9 +41,9 @@ __global__ void rsiKernelPrefix(const float* __restrict__ gainPrefix,
     }
 }
 
-RSI::RSI(int period) : period(period) {}
+tacuda::RSI::RSI(int period) : period(period) {}
 
-void RSI::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::RSI::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period >= size) {
         throw std::invalid_argument("RSI: invalid period");
     }

--- a/src/indicators/RickshawMan.cu
+++ b/src/indicators/RickshawMan.cu
@@ -15,7 +15,7 @@ __global__ void rickshawManKernel(const float *__restrict__ open,
   }
 }
 
-void RickshawMan::calculate(const float *open, const float *high,
+void tacuda::RickshawMan::calculate(const float *open, const float *high,
                             const float *low, const float *close, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -25,7 +25,7 @@ void RickshawMan::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void RickshawMan::calculate(const float *input, float *output,
+void tacuda::RickshawMan::calculate(const float *input, float *output,
                             int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/RiseFall3Methods.cu
+++ b/src/indicators/RiseFall3Methods.cu
@@ -18,7 +18,7 @@ __global__ void riseFall3MethodsKernel(const float *__restrict__ open,
   }
 }
 
-void RiseFall3Methods::calculate(const float *open, const float *high,
+void tacuda::RiseFall3Methods::calculate(const float *open, const float *high,
                                  const float *low, const float *close,
                                  float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -28,7 +28,7 @@ void RiseFall3Methods::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void RiseFall3Methods::calculate(const float *input, float *output,
+void tacuda::RiseFall3Methods::calculate(const float *input, float *output,
                                  int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/SAR.cu
+++ b/src/indicators/SAR.cu
@@ -51,10 +51,10 @@ __global__ void sarKernel(const float* __restrict__ high,
     }
 }
 
-SAR::SAR(float step, float maxAcceleration)
+tacuda::SAR::SAR(float step, float maxAcceleration)
     : step(step), maxAcceleration(maxAcceleration) {}
 
-void SAR::calculate(const float* high, const float* low,
+void tacuda::SAR::calculate(const float* high, const float* low,
                     float* output, int size, cudaStream_t stream) noexcept(false) {
     if (size <= 0) {
         throw std::invalid_argument("SAR: invalid size");
@@ -64,7 +64,7 @@ void SAR::calculate(const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void SAR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::SAR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     calculate(high, low, output, size, stream);

--- a/src/indicators/SAREXT.cu
+++ b/src/indicators/SAREXT.cu
@@ -52,14 +52,14 @@ __global__ void sarextKernel(const float* __restrict__ high,
     }
 }
 
-SAREXT::SAREXT(float startValue, float offsetOnReverse,
+tacuda::SAREXT::SAREXT(float startValue, float offsetOnReverse,
                float accInitLong, float accLong, float accMaxLong,
                float accInitShort, float accShort, float accMaxShort)
     : startValue(startValue), offsetOnReverse(offsetOnReverse),
       accInitLong(accInitLong), accLong(accLong), accMaxLong(accMaxLong),
       accInitShort(accInitShort), accShort(accShort), accMaxShort(accMaxShort) {}
 
-void SAREXT::calculate(const float* high, const float* low,
+void tacuda::SAREXT::calculate(const float* high, const float* low,
                        float* output, int size, cudaStream_t stream) noexcept(false) {
     if (size <= 0) {
         throw std::invalid_argument("SAREXT: invalid size");
@@ -71,7 +71,7 @@ void SAREXT::calculate(const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void SAREXT::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::SAREXT::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     calculate(high, low, output, size, stream);

--- a/src/indicators/SMA.cu
+++ b/src/indicators/SMA.cu
@@ -16,9 +16,9 @@ __global__ void smaKernelPrefix(const float* __restrict__ prefix,
     }
 }
 
-SMA::SMA(int period) : period(period) {}
+tacuda::SMA::SMA(int period) : period(period) {}
 
-void SMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::SMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("SMA: invalid period");
     }

--- a/src/indicators/SUM.cu
+++ b/src/indicators/SUM.cu
@@ -15,9 +15,9 @@ __global__ void sumKernelPrefix(const float *__restrict__ prefix,
   }
 }
 
-SUM::SUM(int period) : period(period) {}
+tacuda::SUM::SUM(int period) : period(period) {}
 
-void SUM::calculate(const float *input, float *output,
+void tacuda::SUM::calculate(const float *input, float *output,
                     int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("SUM: invalid period");

--- a/src/indicators/SeparatingLines.cu
+++ b/src/indicators/SeparatingLines.cu
@@ -15,7 +15,7 @@ __global__ void separatingLinesKernel(const float *__restrict__ open,
   }
 }
 
-void SeparatingLines::calculate(const float *open, const float *high,
+void tacuda::SeparatingLines::calculate(const float *open, const float *high,
                                 const float *low, const float *close,
                                 float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -25,7 +25,7 @@ void SeparatingLines::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void SeparatingLines::calculate(const float *input, float *output,
+void tacuda::SeparatingLines::calculate(const float *input, float *output,
                                 int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/ShootingStar.cu
+++ b/src/indicators/ShootingStar.cu
@@ -15,7 +15,7 @@ __global__ void shootingStarKernel(const float *__restrict__ open,
   }
 }
 
-void ShootingStar::calculate(const float *open, const float *high,
+void tacuda::ShootingStar::calculate(const float *open, const float *high,
                              const float *low, const float *close,
                              float *output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -25,7 +25,7 @@ void ShootingStar::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void ShootingStar::calculate(const float *input, float *output,
+void tacuda::ShootingStar::calculate(const float *input, float *output,
                              int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/ShortLine.cu
+++ b/src/indicators/ShortLine.cu
@@ -14,7 +14,7 @@ __global__ void shortLineKernel(const float *__restrict__ open,
   }
 }
 
-void ShortLine::calculate(const float *open, const float *high,
+void tacuda::ShortLine::calculate(const float *open, const float *high,
                           const float *low, const float *close, float *output,
                           int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -24,7 +24,7 @@ void ShortLine::calculate(const float *open, const float *high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void ShortLine::calculate(const float *input, float *output,
+void tacuda::ShortLine::calculate(const float *input, float *output,
                           int size, cudaStream_t stream) noexcept(false) {
   const float *open = input;
   const float *high = input + size;

--- a/src/indicators/SpinningTop.cu
+++ b/src/indicators/SpinningTop.cu
@@ -14,7 +14,7 @@ __global__ void spinningTopKernel(const float* __restrict__ open,
     }
 }
 
-void SpinningTop::calculate(const float* open, const float* high,
+void tacuda::SpinningTop::calculate(const float* open, const float* high,
                             const float* low, const float* close,
                             float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -24,7 +24,7 @@ void SpinningTop::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void SpinningTop::calculate(const float* input, float* output,
+void tacuda::SpinningTop::calculate(const float* input, float* output,
                             int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/StalledPattern.cu
+++ b/src/indicators/StalledPattern.cu
@@ -18,7 +18,7 @@ __global__ void stalledPatternKernel(const float* __restrict__ open,
     }
 }
 
-void StalledPattern::calculate(const float* open, const float* high,
+void tacuda::StalledPattern::calculate(const float* open, const float* high,
                                const float* low, const float* close,
                                float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -28,7 +28,7 @@ void StalledPattern::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void StalledPattern::calculate(const float* input, float* output,
+void tacuda::StalledPattern::calculate(const float* input, float* output,
                                int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/StdDev.cu
+++ b/src/indicators/StdDev.cu
@@ -20,9 +20,9 @@ __global__ void stddevKernel(const float* __restrict__ input, float* __restrict_
     }
 }
 
-StdDev::StdDev(int period) : period(period) {}
+tacuda::StdDev::StdDev(int period) : period(period) {}
 
-void StdDev::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::StdDev::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("StdDev: invalid period");
     }

--- a/src/indicators/StickSandwich.cu
+++ b/src/indicators/StickSandwich.cu
@@ -18,7 +18,7 @@ __global__ void stickSandwichKernel(const float* __restrict__ open,
     }
 }
 
-void StickSandwich::calculate(const float* open, const float* high,
+void tacuda::StickSandwich::calculate(const float* open, const float* high,
                               const float* low, const float* close,
                               float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -28,7 +28,7 @@ void StickSandwich::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void StickSandwich::calculate(const float* input, float* output,
+void tacuda::StickSandwich::calculate(const float* input, float* output,
                               int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/StochRSI.cu
+++ b/src/indicators/StochRSI.cu
@@ -60,10 +60,10 @@ __global__ void stochRsiKernel(const float *__restrict__ input,
   }
 }
 
-StochRSI::StochRSI(int rsiPeriod, int kPeriod, int dPeriod)
+tacuda::StochRSI::StochRSI(int rsiPeriod, int kPeriod, int dPeriod)
     : rsiPeriod(rsiPeriod), kPeriod(kPeriod), dPeriod(dPeriod) {}
 
-void StochRSI::calculate(const float *input, float *output,
+void tacuda::StochRSI::calculate(const float *input, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
   if (rsiPeriod <= 0 || kPeriod <= 0 || dPeriod <= 0 ||
       size <= rsiPeriod + kPeriod + dPeriod - 2) {

--- a/src/indicators/Stochastic.cu
+++ b/src/indicators/Stochastic.cu
@@ -42,9 +42,9 @@ __global__ void stochasticKernel(const float* __restrict__ high,
     }
 }
 
-Stochastic::Stochastic(int kPeriod, int dPeriod) : kPeriod(kPeriod), dPeriod(dPeriod) {}
+tacuda::Stochastic::Stochastic(int kPeriod, int dPeriod) : kPeriod(kPeriod), dPeriod(dPeriod) {}
 
-void Stochastic::calculate(const float* high, const float* low, const float* close,
+void tacuda::Stochastic::calculate(const float* high, const float* low, const float* close,
                            float* output, int size, cudaStream_t stream) noexcept(false) {
     if (kPeriod <= 0 || dPeriod <= 0 || kPeriod + dPeriod - 1 > size) {
         throw std::invalid_argument("Stochastic: invalid periods");
@@ -56,7 +56,7 @@ void Stochastic::calculate(const float* high, const float* low, const float* clo
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Stochastic::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::Stochastic::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/StochasticFast.cu
+++ b/src/indicators/StochasticFast.cu
@@ -38,9 +38,9 @@ __global__ void stochfKernel(const float* __restrict__ high,
     }
 }
 
-StochasticFast::StochasticFast(int kPeriod, int dPeriod) : kPeriod(kPeriod), dPeriod(dPeriod) {}
+tacuda::StochasticFast::StochasticFast(int kPeriod, int dPeriod) : kPeriod(kPeriod), dPeriod(dPeriod) {}
 
-void StochasticFast::calculate(const float* high, const float* low, const float* close,
+void tacuda::StochasticFast::calculate(const float* high, const float* low, const float* close,
                                float* output, int size, cudaStream_t stream) noexcept(false) {
     if (kPeriod <= 0 || dPeriod <= 0 || kPeriod > size) {
         throw std::invalid_argument("StochasticFast: invalid periods");
@@ -52,7 +52,7 @@ void StochasticFast::calculate(const float* high, const float* low, const float*
     CUDA_CHECK(cudaGetLastError());
 }
 
-void StochasticFast::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::StochasticFast::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/T3.cu
+++ b/src/indicators/T3.cu
@@ -18,9 +18,9 @@ __global__ void t3Kernel(const float *__restrict__ e3,
   }
 }
 
-T3::T3(int period, float vFactor) : period(period), vFactor(vFactor) {}
+tacuda::T3::T3(int period, float vFactor) : period(period), vFactor(vFactor) {}
 
-void T3::calculate(const float *input, float *output,
+void tacuda::T3::calculate(const float *input, float *output,
                    int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || size < 3 * period - 2) {
     throw std::invalid_argument("T3: invalid period");
@@ -34,7 +34,7 @@ void T3::calculate(const float *input, float *output,
   auto e5 = acquireDeviceBuffer<float>(size);
   auto e6 = acquireDeviceBuffer<float>(size);
 
-  EMA ema(period);
+  tacuda::EMA ema(period);
   ema.calculate(input, e1.get(), size, stream);
   int size2 = size - period + 1;
   ema.calculate(e1.get(), e2.get(), size2);

--- a/src/indicators/TEMA.cu
+++ b/src/indicators/TEMA.cu
@@ -18,9 +18,9 @@ __global__ void temaKernel(const float* __restrict__ ema1,
     }
 }
 
-TEMA::TEMA(int period) : period(period) {}
+tacuda::TEMA::TEMA(int period) : period(period) {}
 
-void TEMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::TEMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || size < 3 * period - 2) {
         throw std::invalid_argument("TEMA: invalid period");
     }
@@ -31,7 +31,7 @@ void TEMA::calculate(const float* input, float* output, int size, cudaStream_t s
     auto ema2 = acquireDeviceBuffer<float>(size);
     auto ema3 = acquireDeviceBuffer<float>(size);
 
-    EMA ema(period);
+    tacuda::EMA ema(period);
     ema.calculate(input, ema1.get(), size, stream);
     int size2 = size - period + 1;
     ema.calculate(ema1.get(), ema2.get(), size2);

--- a/src/indicators/TRANGE.cu
+++ b/src/indicators/TRANGE.cu
@@ -21,7 +21,7 @@ __global__ void trangeKernel(const float *__restrict__ high,
   }
 }
 
-void TRANGE::calculate(const float *high, const float *low, const float *close,
+void tacuda::TRANGE::calculate(const float *high, const float *low, const float *close,
                        float *output, int size, cudaStream_t stream) noexcept(false) {
   if (size <= 0) {
     throw std::invalid_argument("TRANGE: invalid size");
@@ -32,7 +32,7 @@ void TRANGE::calculate(const float *high, const float *low, const float *close,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void TRANGE::calculate(const float *input, float *output,
+void tacuda::TRANGE::calculate(const float *input, float *output,
                        int size, cudaStream_t stream) noexcept(false) {
   const float *high = input;
   const float *low = input + size;

--- a/src/indicators/TRIMA.cu
+++ b/src/indicators/TRIMA.cu
@@ -4,9 +4,9 @@
 #include <utils/CudaUtils.h>
 #include <utils/DeviceBufferPool.h>
 
-TRIMA::TRIMA(int period) : period(period) {}
+tacuda::TRIMA::TRIMA(int period) : period(period) {}
 
-void TRIMA::calculate(const float *input, float *output,
+void tacuda::TRIMA::calculate(const float *input, float *output,
                       int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || size < period) {
     throw std::invalid_argument("TRIMA: invalid period");
@@ -17,9 +17,9 @@ void TRIMA::calculate(const float *input, float *output,
 
   auto tmp = acquireDeviceBuffer<float>(size);
 
-  SMA sma1(p1);
+  tacuda::SMA sma1(p1);
   sma1.calculate(input, tmp.get(), size, stream);
   int size2 = size - p1 + 1;
-  SMA sma2(p2);
+  tacuda::SMA sma2(p2);
   sma2.calculate(tmp.get(), output, size2);
 }

--- a/src/indicators/TRIX.cu
+++ b/src/indicators/TRIX.cu
@@ -15,9 +15,9 @@ __global__ void trixKernel(const float* __restrict__ ema3,
     }
 }
 
-TRIX::TRIX(int period) : period(period) {}
+tacuda::TRIX::TRIX(int period) : period(period) {}
 
-void TRIX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::TRIX::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || size < 3 * period - 1) {
         throw std::invalid_argument("TRIX: invalid period");
     }
@@ -28,7 +28,7 @@ void TRIX::calculate(const float* input, float* output, int size, cudaStream_t s
     auto ema2 = acquireDeviceBuffer<float>(size);
     auto ema3 = acquireDeviceBuffer<float>(size);
 
-    EMA ema(period);
+    tacuda::EMA ema(period);
     ema.calculate(input, ema1.get(), size, stream);
     int size2 = size - period + 1;
     ema.calculate(ema1.get(), ema2.get(), size2);

--- a/src/indicators/TSF.cu
+++ b/src/indicators/TSF.cu
@@ -23,9 +23,9 @@ __global__ void tsfKernel(const float* __restrict__ in,
     }
 }
 
-TSF::TSF(int period) : period(period) {}
+tacuda::TSF::TSF(int period) : period(period) {}
 
-void TSF::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::TSF::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("TSF: invalid period");
     }

--- a/src/indicators/Takuri.cu
+++ b/src/indicators/Takuri.cu
@@ -14,7 +14,7 @@ __global__ void takuriKernel(const float* __restrict__ open,
     }
 }
 
-void Takuri::calculate(const float* open, const float* high, const float* low,
+void tacuda::Takuri::calculate(const float* open, const float* high, const float* low,
                        const float* close, float* output,
                        int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -24,7 +24,7 @@ void Takuri::calculate(const float* open, const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void Takuri::calculate(const float* input, float* output,
+void tacuda::Takuri::calculate(const float* input, float* output,
                        int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/TasukiGap.cu
+++ b/src/indicators/TasukiGap.cu
@@ -17,7 +17,7 @@ __global__ void tasukiGapKernel(const float* __restrict__ open,
     }
 }
 
-void TasukiGap::calculate(const float* open, const float* high,
+void tacuda::TasukiGap::calculate(const float* open, const float* high,
                           const float* low, const float* close,
                           float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void TasukiGap::calculate(const float* open, const float* high,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void TasukiGap::calculate(const float* input, float* output,
+void tacuda::TasukiGap::calculate(const float* input, float* output,
                           int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;

--- a/src/indicators/ThreeBlackCrows.cu
+++ b/src/indicators/ThreeBlackCrows.cu
@@ -17,7 +17,7 @@ __global__ void threeBlackCrowsKernel(const float* __restrict__ open,
     }
 }
 
-void ThreeBlackCrows::calculate(const float* open, const float* high, const float* low,
+void tacuda::ThreeBlackCrows::calculate(const float* open, const float* high, const float* low,
                                 const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -26,7 +26,7 @@ void ThreeBlackCrows::calculate(const float* open, const float* high, const floa
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ThreeBlackCrows::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ThreeBlackCrows::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/ThreeInside.cu
+++ b/src/indicators/ThreeInside.cu
@@ -17,7 +17,7 @@ __global__ void threeInsideKernel(const float* __restrict__ open,
     }
 }
 
-void ThreeInside::calculate(const float* open, const float* high, const float* low,
+void tacuda::ThreeInside::calculate(const float* open, const float* high, const float* low,
                             const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -26,7 +26,7 @@ void ThreeInside::calculate(const float* open, const float* high, const float* l
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ThreeInside::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ThreeInside::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/ThreeLineStrike.cu
+++ b/src/indicators/ThreeLineStrike.cu
@@ -18,7 +18,7 @@ __global__ void threeLineStrikeKernel(const float* __restrict__ open,
     }
 }
 
-void ThreeLineStrike::calculate(const float* open, const float* high, const float* low,
+void tacuda::ThreeLineStrike::calculate(const float* open, const float* high, const float* low,
                                 const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -27,7 +27,7 @@ void ThreeLineStrike::calculate(const float* open, const float* high, const floa
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ThreeLineStrike::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ThreeLineStrike::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/ThreeStarsInSouth.cu
+++ b/src/indicators/ThreeStarsInSouth.cu
@@ -17,7 +17,7 @@ __global__ void threeStarsInSouthKernel(const float* __restrict__ open,
     }
 }
 
-void ThreeStarsInSouth::calculate(const float* open, const float* high, const float* low,
+void tacuda::ThreeStarsInSouth::calculate(const float* open, const float* high, const float* low,
                                   const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -26,7 +26,7 @@ void ThreeStarsInSouth::calculate(const float* open, const float* high, const fl
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ThreeStarsInSouth::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ThreeStarsInSouth::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/ThreeWhiteSoldiers.cu
+++ b/src/indicators/ThreeWhiteSoldiers.cu
@@ -17,7 +17,7 @@ __global__ void threeWhiteSoldiersKernel(const float* __restrict__ open,
     }
 }
 
-void ThreeWhiteSoldiers::calculate(const float* open, const float* high, const float* low,
+void tacuda::ThreeWhiteSoldiers::calculate(const float* open, const float* high, const float* low,
                                    const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -26,7 +26,7 @@ void ThreeWhiteSoldiers::calculate(const float* open, const float* high, const f
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ThreeWhiteSoldiers::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ThreeWhiteSoldiers::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/Thrusting.cu
+++ b/src/indicators/Thrusting.cu
@@ -17,7 +17,7 @@ __global__ void thrustingKernel(const float* __restrict__ open,
   }
 }
 
-void Thrusting::calculate(const float* open, const float* high,
+void tacuda::Thrusting::calculate(const float* open, const float* high,
                           const float* low, const float* close,
                           float* output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void Thrusting::calculate(const float* open, const float* high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void Thrusting::calculate(const float* input, float* output,
+void tacuda::Thrusting::calculate(const float* input, float* output,
                           int size, cudaStream_t stream) noexcept(false) {
   const float* open = input;
   const float* high = input + size;

--- a/src/indicators/Tristar.cu
+++ b/src/indicators/Tristar.cu
@@ -16,7 +16,7 @@ __global__ void tristarKernel(const float* __restrict__ open,
   }
 }
 
-void Tristar::calculate(const float* open, const float* high,
+void tacuda::Tristar::calculate(const float* open, const float* high,
                          const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -26,7 +26,7 @@ void Tristar::calculate(const float* open, const float* high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void Tristar::calculate(const float* input, float* output,
+void tacuda::Tristar::calculate(const float* input, float* output,
                          int size, cudaStream_t stream) noexcept(false) {
   const float* open = input;
   const float* high = input + size;

--- a/src/indicators/TwoCrows.cu
+++ b/src/indicators/TwoCrows.cu
@@ -17,7 +17,7 @@ __global__ void twoCrowsKernel(const float* __restrict__ open,
     }
 }
 
-void TwoCrows::calculate(const float* open, const float* high, const float* low,
+void tacuda::TwoCrows::calculate(const float* open, const float* high, const float* low,
                          const float* close, float* output, int size, cudaStream_t stream) noexcept(false) {
     CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
     dim3 block = defaultBlock();
@@ -26,7 +26,7 @@ void TwoCrows::calculate(const float* open, const float* high, const float* low,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void TwoCrows::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::TwoCrows::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* open = input;
     const float* high = input + size;
     const float* low = input + 2 * size;

--- a/src/indicators/TypPrice.cu
+++ b/src/indicators/TypPrice.cu
@@ -13,7 +13,7 @@ __global__ void typPriceKernel(const float* __restrict__ high,
     }
 }
 
-void TypPrice::calculate(const float* high, const float* low, const float* close,
+void tacuda::TypPrice::calculate(const float* high, const float* low, const float* close,
                          float* output, int size, cudaStream_t stream) noexcept(false) {
     if (size <= 0) {
         throw std::invalid_argument("TypPrice: invalid size");
@@ -24,7 +24,7 @@ void TypPrice::calculate(const float* high, const float* low, const float* close
     CUDA_CHECK(cudaGetLastError());
 }
 
-void TypPrice::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::TypPrice::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/ULTOSC.cu
+++ b/src/indicators/ULTOSC.cu
@@ -29,10 +29,10 @@ __global__ void ultoscKernel(const float* __restrict__ high,
     }
 }
 
-ULTOSC::ULTOSC(int shortPeriod, int mediumPeriod, int longPeriod)
+tacuda::ULTOSC::ULTOSC(int shortPeriod, int mediumPeriod, int longPeriod)
     : shortPeriod(shortPeriod), mediumPeriod(mediumPeriod), longPeriod(longPeriod) {}
 
-void ULTOSC::calculate(const float* high, const float* low, const float* close,
+void tacuda::ULTOSC::calculate(const float* high, const float* low, const float* close,
                        float* output, int size, cudaStream_t stream) noexcept(false) {
     if (shortPeriod <= 0 || mediumPeriod <= 0 || longPeriod <= 0 ||
         shortPeriod > mediumPeriod || mediumPeriod > longPeriod ||
@@ -47,7 +47,7 @@ void ULTOSC::calculate(const float* high, const float* low, const float* close,
     CUDA_CHECK(cudaGetLastError());
 }
 
-void ULTOSC::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::ULTOSC::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     const float* high = input;
     const float* low = input + size;
     const float* close = input + 2 * size;

--- a/src/indicators/Unique3River.cu
+++ b/src/indicators/Unique3River.cu
@@ -19,7 +19,7 @@ __global__ void unique3RiverKernel(const float* __restrict__ open,
   }
 }
 
-void Unique3River::calculate(const float* open, const float* high,
+void tacuda::Unique3River::calculate(const float* open, const float* high,
                               const float* low, const float* close,
                               float* output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -29,7 +29,7 @@ void Unique3River::calculate(const float* open, const float* high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void Unique3River::calculate(const float* input, float* output,
+void tacuda::Unique3River::calculate(const float* input, float* output,
                               int size, cudaStream_t stream) noexcept(false) {
   const float* open = input;
   const float* high = input + size;

--- a/src/indicators/UpsideGap2Crows.cu
+++ b/src/indicators/UpsideGap2Crows.cu
@@ -19,7 +19,7 @@ __global__ void upsideGap2CrowsKernel(const float* __restrict__ open,
   }
 }
 
-void UpsideGap2Crows::calculate(const float* open, const float* high,
+void tacuda::UpsideGap2Crows::calculate(const float* open, const float* high,
                                 const float* low, const float* close,
                                 float* output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -29,7 +29,7 @@ void UpsideGap2Crows::calculate(const float* open, const float* high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void UpsideGap2Crows::calculate(const float* input, float* output,
+void tacuda::UpsideGap2Crows::calculate(const float* input, float* output,
                                 int size, cudaStream_t stream) noexcept(false) {
   const float* open = input;
   const float* high = input + size;

--- a/src/indicators/VAR.cu
+++ b/src/indicators/VAR.cu
@@ -20,9 +20,9 @@ __global__ void varKernel(const float* __restrict__ input,
     }
 }
 
-VAR::VAR(int period) : period(period) {}
+tacuda::VAR::VAR(int period) : period(period) {}
 
-void VAR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::VAR::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("VAR: invalid period");
     }

--- a/src/indicators/WILLR.cu
+++ b/src/indicators/WILLR.cu
@@ -26,9 +26,9 @@ __global__ void willrKernel(const float *__restrict__ high,
   }
 }
 
-WILLR::WILLR(int period) : period(period) {}
+tacuda::WILLR::WILLR(int period) : period(period) {}
 
-void WILLR::calculate(const float *high, const float *low, const float *close,
+void tacuda::WILLR::calculate(const float *high, const float *low, const float *close,
                       float *output, int size, cudaStream_t stream) noexcept(false) {
   if (period <= 0 || period > size) {
     throw std::invalid_argument("WILLR: invalid period");
@@ -38,7 +38,7 @@ void WILLR::calculate(const float *high, const float *low, const float *close,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void WILLR::calculate(const float *input, float *output,
+void tacuda::WILLR::calculate(const float *input, float *output,
                       int size, cudaStream_t stream) noexcept(false) {
   const float *high = input;
   const float *low = input + size;

--- a/src/indicators/WMA.cu
+++ b/src/indicators/WMA.cu
@@ -16,9 +16,9 @@ __global__ void wmaKernel(const float* __restrict__ input,
     }
 }
 
-WMA::WMA(int period) : period(period) {}
+tacuda::WMA::WMA(int period) : period(period) {}
 
-void WMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
+void tacuda::WMA::calculate(const float* input, float* output, int size, cudaStream_t stream) noexcept(false) {
     if (period <= 0 || period > size) {
         throw std::invalid_argument("WMA: invalid period");
     }

--- a/src/indicators/WclPrice.cu
+++ b/src/indicators/WclPrice.cu
@@ -12,7 +12,7 @@ __global__ void wclPriceKernel(const float *__restrict__ high,
   }
 }
 
-void WclPrice::calculate(const float *high, const float *low,
+void tacuda::WclPrice::calculate(const float *high, const float *low,
                          const float *close, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
   if (size <= 0) {
@@ -24,7 +24,7 @@ void WclPrice::calculate(const float *high, const float *low,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void WclPrice::calculate(const float *input, float *output,
+void tacuda::WclPrice::calculate(const float *input, float *output,
                          int size, cudaStream_t stream) noexcept(false) {
   const float *high = input;
   const float *low = input + size;

--- a/src/indicators/XSideGap3Methods.cu
+++ b/src/indicators/XSideGap3Methods.cu
@@ -17,7 +17,7 @@ __global__ void xSideGap3MethodsKernel(const float* __restrict__ open,
   }
 }
 
-void XSideGap3Methods::calculate(const float* open, const float* high,
+void tacuda::XSideGap3Methods::calculate(const float* open, const float* high,
                                  const float* low, const float* close,
                                  float* output, int size, cudaStream_t stream) noexcept(false) {
   CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
@@ -27,7 +27,7 @@ void XSideGap3Methods::calculate(const float* open, const float* high,
   CUDA_CHECK(cudaGetLastError());
 }
 
-void XSideGap3Methods::calculate(const float* input, float* output,
+void tacuda::XSideGap3Methods::calculate(const float* input, float* output,
                                  int size, cudaStream_t stream) noexcept(false) {
   const float* open = input;
   const float* high = input + size;


### PR DESCRIPTION
## Summary
- wrap the indicator headers in the `tacuda` namespace so the types are scoped
- qualify indicator usages in CUDA sources and the API layer with the new namespace

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c941294a6c8329a4a2e0744464f445