### PR TITLE
Add stream parameter to ct host APIs

### DIFF
--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -29,79 +29,79 @@ typedef enum ctMaType {
 
 // All APIs copy host->device->host internally for ease of binding.
 CTAPI_EXPORT ctStatus_t ct_sma(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ma(const float *host_input, float *host_output,
-                              int size, int period, ctMaType_t type);
+                              int size, int period, ctMaType_t type, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_wma(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_momentum(const float *host_input, float *host_output,
-                                    int size, int period);
+                                    int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_change(const float *host_input, float *host_output,
-                                  int size, int period);
+                                  int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_roc(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_rocp(const float *host_input, float *host_output,
-                                int size, int period);
+                                int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_rocr(const float *host_input, float *host_output,
-                                int size, int period);
+                                int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_rocr100(const float *host_input, float *host_output,
-                                   int size, int period);
+                                   int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ema(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_dema(const float *host_input, float *host_output,
-                                int size, int period);
+                                int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_tema(const float *host_input, float *host_output,
-                                int size, int period);
+                                int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_t3(const float *host_input, float *host_output,
-                              int size, int period, float vFactor);
+                              int size, int period, float vFactor, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_trima(const float *host_input, float *host_output,
-                                 int size, int period);
+                                 int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_trix(const float *host_input, float *host_output,
-                                int size, int period);
+                                int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_max(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_min(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_maxindex(const float *host_input, float *host_output,
-                                    int size, int period);
+                                    int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_minindex(const float *host_input, float *host_output,
-                                    int size, int period);
+                                    int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_minmax(const float *host_input, float *host_min,
-                                  float *host_max, int size, int period);
+                                  float *host_max, int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_minmaxindex(const float *host_input,
                                        float *host_minidx, float *host_maxidx,
-                                       int size, int period);
+                                       int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_stddev(const float *host_input, float *host_output,
-                                  int size, int period);
+                                  int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_var(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_sum(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_rsi(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_kama(const float *host_input, float *host_output,
                                 int size, int period, int fastPeriod,
-                                int slowPeriod);
+                                int slowPeriod, cudaStream_t stream = 0);
 // MACD line only (EMA_fast - EMA_slow)
 CTAPI_EXPORT ctStatus_t ct_macd_line(const float *host_input,
                                      float *host_output, int size,
-                                     int fastPeriod, int slowPeriod);
+                                     int fastPeriod, int slowPeriod, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_macd(const float *host_input, float *host_macd,
                                 float *host_signal, float *host_hist, int size,
                                 int fastPeriod, int slowPeriod,
-                                int signalPeriod, ctMaType_t type);
+                                int signalPeriod, ctMaType_t type, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_macdfix(const float *host_input, float *host_macd,
                                    float *host_signal, float *host_hist,
-                                   int size, int signalPeriod);
+                                   int size, int signalPeriod, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_mama(const float *host_input, float *host_mama,
                                 float *host_fama, int size, float fastLimit,
-                                float slowLimit);
+                                float slowLimit, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_apo(const float *host_input, float *host_output,
-                               int size, int fastPeriod, int slowPeriod);
+                               int size, int fastPeriod, int slowPeriod, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ppo(const float *host_input, float *host_output,
-                               int size, int fastPeriod, int slowPeriod);
+                               int size, int fastPeriod, int slowPeriod, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_pvo(const float *host_volume, float *host_output,
-                               int size, int fastPeriod, int slowPeriod);
+                               int size, int fastPeriod, int slowPeriod, cudaStream_t stream = 0);
 // Device-pointer variants that operate directly on GPU memory.
 CTAPI_EXPORT ctStatus_t ct_sma_device(const float *device_input,
                                       float *device_output, int size,
@@ -197,7 +197,7 @@ CTAPI_EXPORT ctStatus_t ct_pvo_device(const float *device_volume,
 CTAPI_EXPORT ctStatus_t ct_bbands(const float *host_input, float *host_upper,
                                   float *host_middle, float *host_lower,
                                   int size, int period, float upperMul,
-                                  float lowerMul);
+                                  float lowerMul, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_atr(const float *host_high, const float *host_low,
                                const float *host_close, float *host_output,
                                int size, int period, float initial,
@@ -233,10 +233,10 @@ CTAPI_EXPORT ctStatus_t ct_adxr(const float *host_high, const float *host_low,
                                 int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_plus_dm(const float *host_high,
                                    const float *host_low, float *host_output,
-                                   int size, int period);
+                                   int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_minus_dm(const float *host_high,
                                     const float *host_low, float *host_output,
-                                    int size, int period);
+                                    int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_plus_di(const float *host_high,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
@@ -248,397 +248,397 @@ CTAPI_EXPORT ctStatus_t ct_minus_di(const float *host_high,
 CTAPI_EXPORT ctStatus_t ct_mfi(const float *host_high, const float *host_low,
                                const float *host_close,
                                const float *host_volume, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_obv(const float *host_price,
                                const float *host_volume, float *host_output,
-                               int size);
+                               int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_sar(const float *host_high, const float *host_low,
                                float *host_output, int size, float step,
-                               float maxAcceleration);
+                               float maxAcceleration, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_sarext(const float *host_high, const float *host_low,
                                   float *host_output, int size,
                                   float startValue, float offsetOnReverse,
                                   float accInitLong, float accLong,
                                   float accMaxLong, float accInitShort,
-                                  float accShort, float accMaxShort);
+                                  float accShort, float accMaxShort, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_aroon(const float *host_high, const float *host_low,
                                  float *host_up, float *host_down,
                                  float *host_osc, int size, int upPeriod,
-                                 int downPeriod);
+                                 int downPeriod, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_aroonosc(const float *host_high,
                                     const float *host_low, float *host_output,
-                                    int size, int period);
+                                    int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_adosc(const float *host_high, const float *host_low,
                                  const float *host_close,
                                  const float *host_volume, float *host_output,
-                                 int size, int shortPeriod, int longPeriod);
+                                 int size, int shortPeriod, int longPeriod, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ultosc(const float *host_high, const float *host_low,
                                   const float *host_close, float *host_output,
                                   int size, int shortPeriod, int mediumPeriod,
-                                  int longPeriod);
+                                  int longPeriod, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ad(const float *host_high, const float *host_low,
                               const float *host_close, const float *host_volume,
-                              float *host_output, int size);
+                              float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_avgprice(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size);
+                                    int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_medprice(const float *host_high,
                                     const float *host_low, float *host_output,
-                                    int size);
+                                    int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_typprice(const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size);
+                                    int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_wclprice(const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size);
+                                    int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_willr(const float *host_high, const float *host_low,
                                  const float *host_close, float *host_output,
-                                 int size, int period);
+                                 int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_midpoint(const float *host_input, float *host_output,
-                                    int size, int period);
+                                    int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_midprice(const float *host_high,
                                     const float *host_low, float *host_output,
-                                    int size, int period);
+                                    int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_beta(const float *host_x, const float *host_y,
-                                float *host_output, int size, int period);
+                                float *host_output, int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_bop(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
-                               float *host_output, int size);
+                               float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_doji(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size);
+                                    int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_hammer(const float *host_open,
                                       const float *host_high,
                                       const float *host_low,
                                       const float *host_close,
-                                      float *host_output, int size);
+                                      float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_inverted_hammer(const float *host_open,
                                                const float *host_high,
                                                const float *host_low,
                                                const float *host_close,
-                                               float *host_output, int size);
+                                               float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_bullish_engulfing(const float *host_open,
                                                  const float *host_high,
                                                  const float *host_low,
                                                  const float *host_close,
-                                                 float *host_output, int size);
+                                                 float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_bearish_engulfing(const float *host_open,
                                                  const float *host_high,
                                                  const float *host_low,
                                                  const float *host_close,
-                                                 float *host_output, int size);
+                                                 float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_three_white_soldiers(
     const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
+    const float *host_close, float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_abandoned_baby(const float *host_open,
                                               const float *host_high,
                                               const float *host_low,
                                               const float *host_close,
-                                              float *host_output, int size);
+                                              float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_advance_block(const float *host_open,
                                              const float *host_high,
                                              const float *host_low,
                                              const float *host_close,
-                                             float *host_output, int size);
+                                             float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_belt_hold(const float *host_open,
                                          const float *host_high,
                                          const float *host_low,
                                          const float *host_close,
-                                         float *host_output, int size);
+                                         float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_breakaway(const float *host_open,
                                          const float *host_high,
                                          const float *host_low,
                                          const float *host_close,
-                                         float *host_output, int size);
+                                         float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_two_crows(const float *host_open,
                                          const float *host_high,
                                          const float *host_low,
                                          const float *host_close,
-                                         float *host_output, int size);
+                                         float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_three_black_crows(const float *host_open,
                                                  const float *host_high,
                                                  const float *host_low,
                                                  const float *host_close,
-                                                 float *host_output, int size);
+                                                 float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_three_inside(const float *host_open,
                                             const float *host_high,
                                             const float *host_low,
                                             const float *host_close,
-                                            float *host_output, int size);
+                                            float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_three_line_strike(const float *host_open,
                                                  const float *host_high,
                                                  const float *host_low,
                                                  const float *host_close,
-                                                 float *host_output, int size);
+                                                 float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_three_stars_in_south(
     const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
+    const float *host_close, float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_closing_marubozu(const float *host_open,
                                                 const float *host_high,
                                                 const float *host_low,
                                                 const float *host_close,
-                                                float *host_output, int size);
+                                                float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_conceal_baby_swallow(
     const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
+    const float *host_close, float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_counterattack(const float *host_open,
                                              const float *host_high,
                                              const float *host_low,
                                              const float *host_close,
-                                             float *host_output, int size);
+                                             float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_dark_cloud_cover(const float *host_open,
                                                 const float *host_high,
                                                 const float *host_low,
                                                 const float *host_close,
-                                                float *host_output, int size);
+                                                float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_doji_star(const float *host_open,
                                          const float *host_high,
                                          const float *host_low,
                                          const float *host_close,
-                                         float *host_output, int size);
+                                         float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_dragonfly_doji(const float *host_open,
                                               const float *host_high,
                                               const float *host_low,
                                               const float *host_close,
-                                              float *host_output, int size);
+                                              float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_engulfing(const float *host_open,
                                          const float *host_high,
                                          const float *host_low,
                                          const float *host_close,
-                                         float *host_output, int size);
+                                         float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_evening_doji_star(const float *host_open,
                                                  const float *host_high,
                                                  const float *host_low,
                                                  const float *host_close,
-                                                 float *host_output, int size);
+                                                 float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_evening_star(const float *host_open,
                                             const float *host_high,
                                             const float *host_low,
                                             const float *host_close,
-                                            float *host_output, int size);
+                                            float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_gap_side_side_white(
     const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
+    const float *host_close, float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_gravestone_doji(const float *host_open,
                                                const float *host_high,
                                                const float *host_low,
                                                const float *host_close,
-                                               float *host_output, int size);
+                                               float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_hanging_man(const float *host_open,
                                            const float *host_high,
                                            const float *host_low,
                                            const float *host_close,
-                                           float *host_output, int size);
+                                           float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_harami(const float *host_open,
                                       const float *host_high,
                                       const float *host_low,
                                       const float *host_close,
-                                      float *host_output, int size);
+                                      float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_harami_cross(const float *host_open,
                                             const float *host_high,
                                             const float *host_low,
                                             const float *host_close,
-                                            float *host_output, int size);
+                                            float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_high_wave(const float *host_open,
                                          const float *host_high,
                                          const float *host_low,
                                          const float *host_close,
-                                         float *host_output, int size);
+                                         float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_hikkake(const float *host_open,
                                        const float *host_high,
                                        const float *host_low,
                                        const float *host_close,
-                                       float *host_output, int size);
+                                       float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_hikkake_mod(const float *host_open,
                                            const float *host_high,
                                            const float *host_low,
                                            const float *host_close,
-                                           float *host_output, int size);
+                                           float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_homing_pigeon(const float *host_open,
                                              const float *host_high,
                                              const float *host_low,
                                              const float *host_close,
-                                             float *host_output, int size);
+                                             float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_identical_three_crows(
     const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
+    const float *host_close, float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_in_neck(const float *host_open,
                                        const float *host_high,
                                        const float *host_low,
                                        const float *host_close,
-                                       float *host_output, int size);
+                                       float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_kicking(const float *host_open,
                                        const float *host_high,
                                        const float *host_low,
                                        const float *host_close,
-                                       float *host_output, int size);
+                                       float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_kicking_by_length(const float *host_open,
                                                  const float *host_high,
                                                  const float *host_low,
                                                  const float *host_close,
-                                                 float *host_output, int size);
+                                                 float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_ladder_bottom(const float *host_open,
                                              const float *host_high,
                                              const float *host_low,
                                              const float *host_close,
-                                             float *host_output, int size);
+                                             float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_long_legged_doji(const float *host_open,
                                                 const float *host_high,
                                                 const float *host_low,
                                                 const float *host_close,
-                                                float *host_output, int size);
+                                                float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_long_line(const float *host_open,
                                          const float *host_high,
                                          const float *host_low,
                                          const float *host_close,
-                                         float *host_output, int size);
+                                         float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_marubozu(const float *host_open,
                                         const float *host_high,
                                         const float *host_low,
                                         const float *host_close,
-                                        float *host_output, int size);
+                                        float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_matching_low(const float *host_open,
                                             const float *host_high,
                                             const float *host_low,
                                             const float *host_close,
-                                            float *host_output, int size);
+                                            float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_mat_hold(const float *host_open,
                                         const float *host_high,
                                         const float *host_low,
                                         const float *host_close,
-                                        float *host_output, int size);
+                                        float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_morning_doji_star(const float *host_open,
                                                  const float *host_high,
                                                  const float *host_low,
                                                  const float *host_close,
-                                                 float *host_output, int size);
+                                                 float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_morning_star(const float *host_open,
                                             const float *host_high,
                                             const float *host_low,
                                             const float *host_close,
-                                            float *host_output, int size);
+                                            float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_on_neck(const float *host_open,
                                        const float *host_high,
                                        const float *host_low,
                                        const float *host_close,
-                                       float *host_output, int size);
+                                       float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_piercing(const float *host_open,
                                         const float *host_high,
                                         const float *host_low,
                                         const float *host_close,
-                                        float *host_output, int size);
+                                        float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_rickshaw_man(const float *host_open,
                                             const float *host_high,
                                             const float *host_low,
                                             const float *host_close,
-                                            float *host_output, int size);
+                                            float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_rise_fall3_methods(const float *host_open,
                                                   const float *host_high,
                                                   const float *host_low,
                                                   const float *host_close,
-                                                  float *host_output, int size);
+                                                  float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_separating_lines(const float *host_open,
                                                 const float *host_high,
                                                 const float *host_low,
                                                 const float *host_close,
-                                                float *host_output, int size);
+                                                float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_shooting_star(const float *host_open,
                                              const float *host_high,
                                              const float *host_low,
                                              const float *host_close,
-                                             float *host_output, int size);
+                                             float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_short_line(const float *host_open,
                                           const float *host_high,
                                           const float *host_low,
                                           const float *host_close,
-                                          float *host_output, int size);
+                                          float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_spinning_top(const float *host_open,
                                             const float *host_high,
                                             const float *host_low,
                                             const float *host_close,
-                                            float *host_output, int size);
+                                            float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_stalled_pattern(const float *host_open,
                                                const float *host_high,
                                                const float *host_low,
                                                const float *host_close,
-                                               float *host_output, int size);
+                                               float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_stick_sandwich(const float *host_open,
                                               const float *host_high,
                                               const float *host_low,
                                               const float *host_close,
-                                              float *host_output, int size);
+                                              float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_takuri(const float *host_open,
                                       const float *host_high,
                                       const float *host_low,
                                       const float *host_close,
-                                      float *host_output, int size);
+                                      float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_tasuki_gap(const float *host_open,
                                           const float *host_high,
                                           const float *host_low,
                                           const float *host_close,
-                                          float *host_output, int size);
+                                          float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_thrusting(const float *host_open,
                                          const float *host_high,
                                          const float *host_low,
                                          const float *host_close,
-                                         float *host_output, int size);
+                                         float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_tristar(const float *host_open,
                                        const float *host_high,
                                        const float *host_low,
                                        const float *host_close,
-                                       float *host_output, int size);
+                                       float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_unique_3_river(const float *host_open,
                                               const float *host_high,
                                               const float *host_low,
                                               const float *host_close,
-                                              float *host_output, int size);
+                                              float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_upside_gap_2_crows(const float *host_open,
                                                   const float *host_high,
                                                   const float *host_low,
                                                   const float *host_close,
-                                                  float *host_output, int size);
+                                                  float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cdl_xside_gap_3_methods(
     const float *host_open, const float *host_high, const float *host_low,
-    const float *host_close, float *host_output, int size);
+    const float *host_close, float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_cmo(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_correl(const float *host_x, const float *host_y,
-                                  float *host_output, int size, int period);
+                                  float *host_output, int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_dx(const float *host_high, const float *host_low,
                               const float *host_close, float *host_output,
                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_linearreg(const float *host_input,
-                                     float *host_output, int size, int period);
+                                     float *host_output, int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_linearreg_slope(const float *host_input,
                                            float *host_output, int size,
-                                           int period);
+                                           int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_linearreg_intercept(const float *host_input,
                                                float *host_output, int size,
-                                               int period);
+                                               int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_linearreg_angle(const float *host_input,
                                            float *host_output, int size,
-                                           int period);
+                                           int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_tsf(const float *host_input, float *host_output,
-                               int size, int period);
+                               int size, int period, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ht_dcperiod(const float *host_input,
-                                       float *host_output, int size);
+                                       float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ht_dcphase(const float *host_input,
-                                      float *host_output, int size);
+                                      float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ht_phasor(const float *host_input,
                                      float *host_inphase,
-                                     float *host_quadrature, int size);
+                                     float *host_quadrature, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ht_sine(const float *host_input, float *host_sine,
-                                   float *host_leadsine, int size);
+                                   float *host_leadsine, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ht_trendline(const float *host_input,
-                                        float *host_output, int size);
+                                        float *host_output, int size, cudaStream_t stream = 0);
 CTAPI_EXPORT ctStatus_t ct_ht_trendmode(const float *host_input,
-                                        float *host_output, int size);
+                                        float *host_output, int size, cudaStream_t stream = 0);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -394,124 +394,124 @@ static ctStatus_t run_ohlc_indicator(T &ind, const float *h_high,
 extern "C" {
 
 ctStatus_t ct_sma(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::SMA sma(period);
-  return run_indicator(sma, host_input, host_output, size);
+  return run_indicator(sma, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_ma(const float *host_input, float *host_output, int size,
-                 int period, ctMaType_t type) {
+                 int period, ctMaType_t type, cudaStream_t stream) {
   tacuda::MA ma(period, static_cast<tacuda::MAType>(type));
-  return run_indicator(ma, host_input, host_output, size);
+  return run_indicator(ma, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_wma(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::WMA wma(period);
-  return run_indicator(wma, host_input, host_output, size);
+  return run_indicator(wma, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_momentum(const float *host_input, float *host_output, int size,
-                       int period) {
+                       int period, cudaStream_t stream) {
   tacuda::Momentum mom(period);
-  return run_indicator(mom, host_input, host_output, size);
+  return run_indicator(mom, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_change(const float *host_input, float *host_output, int size,
-                     int period) {
+                     int period, cudaStream_t stream) {
   tacuda::Change ch(period);
-  return run_indicator(ch, host_input, host_output, size);
+  return run_indicator(ch, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_roc(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::ROC roc(period);
-  return run_indicator(roc, host_input, host_output, size);
+  return run_indicator(roc, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_rocp(const float *host_input, float *host_output, int size,
-                   int period) {
+                   int period, cudaStream_t stream) {
   tacuda::ROCP rocp(period);
-  return run_indicator(rocp, host_input, host_output, size);
+  return run_indicator(rocp, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_rocr(const float *host_input, float *host_output, int size,
-                   int period) {
+                   int period, cudaStream_t stream) {
   tacuda::ROCR rocr(period);
-  return run_indicator(rocr, host_input, host_output, size);
+  return run_indicator(rocr, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_rocr100(const float *host_input, float *host_output, int size,
-                      int period) {
+                      int period, cudaStream_t stream) {
   tacuda::ROCR100 rocr100(period);
-  return run_indicator(rocr100, host_input, host_output, size);
+  return run_indicator(rocr100, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_ema(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::EMA ema(period);
-  return run_indicator(ema, host_input, host_output, size);
+  return run_indicator(ema, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_dema(const float *host_input, float *host_output, int size,
-                   int period) {
+                   int period, cudaStream_t stream) {
   tacuda::DEMA dema(period);
-  return run_indicator(dema, host_input, host_output, size);
+  return run_indicator(dema, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_tema(const float *host_input, float *host_output, int size,
-                   int period) {
+                   int period, cudaStream_t stream) {
   tacuda::TEMA tema(period);
-  return run_indicator(tema, host_input, host_output, size);
+  return run_indicator(tema, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_t3(const float *host_input, float *host_output, int size,
-                 int period, float vFactor) {
+                 int period, float vFactor, cudaStream_t stream) {
   tacuda::T3 t3(period, vFactor);
-  return run_indicator(t3, host_input, host_output, size);
+  return run_indicator(t3, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_trima(const float *host_input, float *host_output, int size,
-                    int period) {
+                    int period, cudaStream_t stream) {
   tacuda::TRIMA trima(period);
-  return run_indicator(trima, host_input, host_output, size);
+  return run_indicator(trima, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_trix(const float *host_input, float *host_output, int size,
-                   int period) {
+                   int period, cudaStream_t stream) {
   tacuda::TRIX trix(period);
-  return run_indicator(trix, host_input, host_output, size);
+  return run_indicator(trix, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_max(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::MAX mx(period);
-  return run_indicator(mx, host_input, host_output, size);
+  return run_indicator(mx, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_min(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::MIN mn(period);
-  return run_indicator(mn, host_input, host_output, size);
+  return run_indicator(mn, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_maxindex(const float *host_input, float *host_output, int size,
-                       int period) {
+                       int period, cudaStream_t stream) {
   tacuda::MAXINDEX mi(period);
-  return run_indicator(mi, host_input, host_output, size);
+  return run_indicator(mi, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_minindex(const float *host_input, float *host_output, int size,
-                       int period) {
+                       int period, cudaStream_t stream) {
   tacuda::MININDEX mi(period);
-  return run_indicator(mi, host_input, host_output, size);
+  return run_indicator(mi, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_minmax(const float *host_input, float *host_min, float *host_max,
-                     int size, int period) {
+                     int size, int period, cudaStream_t stream) {
   tacuda::MINMAX mm(period);
   std::vector<float> tmp(2 * size);
-  ctStatus_t rc = run_indicator(mm, host_input, tmp.data(), size, 2);
+  ctStatus_t rc = run_indicator(mm, host_input, tmp.data(), size, 2, stream);
   if (rc != CT_STATUS_SUCCESS)
     return rc;
   std::memcpy(host_min, tmp.data(), size * sizeof(float));
@@ -520,10 +520,10 @@ ctStatus_t ct_minmax(const float *host_input, float *host_min, float *host_max,
 }
 
 ctStatus_t ct_minmaxindex(const float *host_input, float *host_minidx,
-                          float *host_maxidx, int size, int period) {
+                          float *host_maxidx, int size, int period, cudaStream_t stream) {
   tacuda::MINMAXINDEX mm(period);
   std::vector<float> tmp(2 * size);
-  ctStatus_t rc = run_indicator(mm, host_input, tmp.data(), size, 2);
+  ctStatus_t rc = run_indicator(mm, host_input, tmp.data(), size, 2, stream);
   if (rc != CT_STATUS_SUCCESS)
     return rc;
   std::memcpy(host_minidx, tmp.data(), size * sizeof(float));
@@ -532,48 +532,48 @@ ctStatus_t ct_minmaxindex(const float *host_input, float *host_minidx,
 }
 
 ctStatus_t ct_stddev(const float *host_input, float *host_output, int size,
-                     int period) {
+                     int period, cudaStream_t stream) {
   tacuda::StdDev sd(period);
-  return run_indicator(sd, host_input, host_output, size);
+  return run_indicator(sd, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_var(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::VAR vr(period);
-  return run_indicator(vr, host_input, host_output, size);
+  return run_indicator(vr, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_sum(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::SUM sum(period);
-  return run_indicator(sum, host_input, host_output, size);
+  return run_indicator(sum, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_rsi(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::RSI rsi(period);
-  return run_indicator(rsi, host_input, host_output, size);
+  return run_indicator(rsi, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_kama(const float *host_input, float *host_output, int size,
-                   int period, int fastPeriod, int slowPeriod) {
+                   int period, int fastPeriod, int slowPeriod, cudaStream_t stream) {
   tacuda::KAMA kama(period, fastPeriod, slowPeriod);
-  return run_indicator(kama, host_input, host_output, size);
+  return run_indicator(kama, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_macd_line(const float *host_input, float *host_output, int size,
-                        int fastPeriod, int slowPeriod) {
+                        int fastPeriod, int slowPeriod, cudaStream_t stream) {
   tacuda::MACD macd(fastPeriod, slowPeriod);
-  return run_indicator(macd, host_input, host_output, size);
+  return run_indicator(macd, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_macd(const float *host_input, float *host_macd,
                    float *host_signal, float *host_hist, int size,
                    int fastPeriod, int slowPeriod, int signalPeriod,
-                   ctMaType_t type) {
+                   ctMaType_t type, cudaStream_t stream) {
   tacuda::MACDEXT macd(fastPeriod, slowPeriod, signalPeriod, static_cast<tacuda::MAType>(type));
   std::vector<float> tmp(3 * size);
-  ctStatus_t rc = run_indicator(macd, host_input, tmp.data(), size, 3);
+  ctStatus_t rc = run_indicator(macd, host_input, tmp.data(), size, 3, stream);
   if (rc != CT_STATUS_SUCCESS)
     return rc;
   std::memcpy(host_macd, tmp.data(), size * sizeof(float));
@@ -584,10 +584,10 @@ ctStatus_t ct_macd(const float *host_input, float *host_macd,
 
 ctStatus_t ct_macdfix(const float *host_input, float *host_macd,
                       float *host_signal, float *host_hist, int size,
-                      int signalPeriod) {
+                      int signalPeriod, cudaStream_t stream) {
   tacuda::MACDFIX macd(signalPeriod);
   std::vector<float> tmp(3 * size);
-  ctStatus_t rc = run_indicator(macd, host_input, tmp.data(), size, 3);
+  ctStatus_t rc = run_indicator(macd, host_input, tmp.data(), size, 3, stream);
   if (rc != CT_STATUS_SUCCESS)
     return rc;
   std::memcpy(host_macd, tmp.data(), size * sizeof(float));
@@ -597,10 +597,10 @@ ctStatus_t ct_macdfix(const float *host_input, float *host_macd,
 }
 
 ctStatus_t ct_mama(const float *host_input, float *host_mama, float *host_fama,
-                   int size, float fastLimit, float slowLimit) {
+                   int size, float fastLimit, float slowLimit, cudaStream_t stream) {
   tacuda::MAMA ma(fastLimit, slowLimit);
   std::vector<float> tmp(2 * size);
-  ctStatus_t rc = run_indicator(ma, host_input, tmp.data(), size, 2);
+  ctStatus_t rc = run_indicator(ma, host_input, tmp.data(), size, 2, stream);
   if (rc != CT_STATUS_SUCCESS)
     return rc;
   std::memcpy(host_mama, tmp.data(), size * sizeof(float));
@@ -609,21 +609,21 @@ ctStatus_t ct_mama(const float *host_input, float *host_mama, float *host_fama,
 }
 
 ctStatus_t ct_apo(const float *host_input, float *host_output, int size,
-                  int fastPeriod, int slowPeriod) {
+                  int fastPeriod, int slowPeriod, cudaStream_t stream) {
   tacuda::APO apo(fastPeriod, slowPeriod);
-  return run_indicator(apo, host_input, host_output, size);
+  return run_indicator(apo, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_ppo(const float *host_input, float *host_output, int size,
-                  int fastPeriod, int slowPeriod) {
+                  int fastPeriod, int slowPeriod, cudaStream_t stream) {
   tacuda::PPO ppo(fastPeriod, slowPeriod);
-  return run_indicator(ppo, host_input, host_output, size);
+  return run_indicator(ppo, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_pvo(const float *host_volume, float *host_output, int size,
-                  int fastPeriod, int slowPeriod) {
+                  int fastPeriod, int slowPeriod, cudaStream_t stream) {
   tacuda::PVO pvo(fastPeriod, slowPeriod);
-  return run_indicator(pvo, host_volume, host_output, size);
+  return run_indicator(pvo, host_volume, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_sma_device(const float *device_input, float *device_output,
@@ -808,10 +808,10 @@ ctStatus_t ct_pvo_device(const float *device_volume, float *device_output,
 
 ctStatus_t ct_bbands(const float *host_input, float *host_upper,
                      float *host_middle, float *host_lower, int size,
-                     int period, float upperMul, float lowerMul) {
+                     int period, float upperMul, float lowerMul, cudaStream_t stream) {
   tacuda::BBANDS bb(period, upperMul, lowerMul);
   std::vector<float> tmp(3 * size);
-  ctStatus_t rc = run_indicator(bb, host_input, tmp.data(), size, 3);
+  ctStatus_t rc = run_indicator(bb, host_input, tmp.data(), size, 3, stream);
   if (rc != CT_STATUS_SUCCESS) {
     return rc;
   }
@@ -913,7 +913,7 @@ ctStatus_t ct_adxr(const float *host_high, const float *host_low,
 }
 
 ctStatus_t ct_plus_dm(const float *host_high, const float *host_low,
-                      float *host_output, int size, int period) {
+                      float *host_output, int size, int period, cudaStream_t stream) {
   tacuda::PlusDM pdm(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -936,34 +936,39 @@ ctStatus_t ct_plus_dm(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    pdm.calculate(d_high.get(), d_low.get(), d_out.get(), size);
+    pdm.calculate(d_high.get(), d_low.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_minus_dm(const float *host_high, const float *host_low,
-                       float *host_output, int size, int period) {
+                       float *host_output, int size, int period, cudaStream_t stream) {
   tacuda::MinusDM mdm(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -986,27 +991,32 @@ ctStatus_t ct_minus_dm(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    mdm.calculate(d_high.get(), d_low.get(), d_out.get(), size);
+    mdm.calculate(d_high.get(), d_low.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
@@ -1030,7 +1040,7 @@ ctStatus_t ct_minus_di(const float *host_high, const float *host_low,
 
 ctStatus_t ct_sar(const float *host_high, const float *host_low,
                   float *host_output, int size, float step,
-                  float maxAcceleration) {
+                  float maxAcceleration, cudaStream_t stream) {
   tacuda::SAR sar(step, maxAcceleration);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1053,27 +1063,32 @@ ctStatus_t ct_sar(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    sar.calculate(d_high.get(), d_low.get(), d_out.get(), size);
+    sar.calculate(d_high.get(), d_low.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
@@ -1083,7 +1098,7 @@ ctStatus_t ct_sarext(const float *host_high, const float *host_low,
                      float *host_output, int size, float startValue,
                      float offsetOnReverse, float accInitLong, float accLong,
                      float accMaxLong, float accInitShort, float accShort,
-                     float accMaxShort) {
+                     float accMaxShort, cudaStream_t stream) {
   tacuda::SAREXT sar(startValue, offsetOnReverse, accInitLong, accLong, accMaxLong,
              accInitShort, accShort, accMaxShort);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
@@ -1107,27 +1122,32 @@ ctStatus_t ct_sarext(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    sar.calculate(d_high.get(), d_low.get(), d_out.get(), size);
+    sar.calculate(d_high.get(), d_low.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
@@ -1135,7 +1155,7 @@ ctStatus_t ct_sarext(const float *host_high, const float *host_low,
 
 ctStatus_t ct_aroon(const float *host_high, const float *host_low,
                     float *host_up, float *host_down, float *host_osc, int size,
-                    int upPeriod, int downPeriod) {
+                    int upPeriod, int downPeriod, cudaStream_t stream) {
   tacuda::Aroon aroon(upPeriod, downPeriod);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1158,28 +1178,33 @@ ctStatus_t ct_aroon(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    aroon.calculate(d_high.get(), d_low.get(), d_out.get(), size);
+    aroon.calculate(d_high.get(), d_low.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
   std::vector<float> tmpHost(3 * size);
-  err = cudaMemcpy(tmpHost.data(), d_out.get(), 3 * size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(tmpHost.data(), d_out.get(), 3 * size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   std::memcpy(host_up, tmpHost.data(), size * sizeof(float));
@@ -1190,7 +1215,7 @@ ctStatus_t ct_aroon(const float *host_high, const float *host_low,
 }
 
 ctStatus_t ct_aroonosc(const float *host_high, const float *host_low,
-                       float *host_output, int size, int period) {
+                       float *host_output, int size, int period, cudaStream_t stream) {
   tacuda::AroonOscillator ind(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1213,27 +1238,32 @@ ctStatus_t ct_aroonosc(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    ind.calculate(d_high.get(), d_low.get(), d_out.get(), size);
+    ind.calculate(d_high.get(), d_low.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
@@ -1242,7 +1272,7 @@ ctStatus_t ct_aroonosc(const float *host_high, const float *host_low,
 ctStatus_t ct_adosc(const float *host_high, const float *host_low,
                     const float *host_close, const float *host_volume,
                     float *host_output, int size, int shortPeriod,
-                    int longPeriod) {
+                    int longPeriod, cudaStream_t stream) {
   tacuda::ADOSC adosc(shortPeriod, longPeriod);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_vol{nullptr}, d_out{nullptr};
@@ -1278,38 +1308,43 @@ ctStatus_t ct_adosc(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_close.get(), host_close, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_close.get(), host_close, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_vol.get(), host_volume, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_vol.get(), host_volume, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
     adosc.calculate(d_high.get(), d_low.get(), d_close.get(), d_vol.get(),
-                    d_out.get(), size);
+                    d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
@@ -1317,7 +1352,7 @@ ctStatus_t ct_adosc(const float *host_high, const float *host_low,
 
 ctStatus_t ct_ad(const float *host_high, const float *host_low,
                  const float *host_close, const float *host_volume,
-                 float *host_output, int size) {
+                 float *host_output, int size, cudaStream_t stream) {
   tacuda::AD ad;
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_vol{nullptr}, d_out{nullptr};
@@ -1353,38 +1388,43 @@ ctStatus_t ct_ad(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_close.get(), host_close, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_close.get(), host_close, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_vol.get(), host_volume, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_vol.get(), host_volume, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
     ad.calculate(d_high.get(), d_low.get(), d_close.get(), d_vol.get(),
-                 d_out.get(), size);
+                 d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
@@ -1392,7 +1432,7 @@ ctStatus_t ct_ad(const float *host_high, const float *host_low,
 
 ctStatus_t ct_avgprice(const float *host_open, const float *host_high,
                        const float *host_low, const float *host_close,
-                       float *host_output, int size) {
+                       float *host_output, int size, cudaStream_t stream) {
   tacuda::AvgPrice ap;
   DeviceBuffer d_open{nullptr}, d_high{nullptr}, d_low{nullptr},
       d_close{nullptr}, d_out{nullptr};
@@ -1428,45 +1468,50 @@ ctStatus_t ct_avgprice(const float *host_open, const float *host_high,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_open.get(), host_open, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_open.get(), host_open, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_close.get(), host_close, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_close.get(), host_close, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
     ap.calculate(d_open.get(), d_high.get(), d_low.get(), d_close.get(),
-                 d_out.get(), size);
+                 d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_medprice(const float *host_high, const float *host_low,
-                       float *host_output, int size) {
+                       float *host_output, int size, cudaStream_t stream) {
   tacuda::MedPrice mp;
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1489,34 +1534,39 @@ ctStatus_t ct_medprice(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    mp.calculate(d_high.get(), d_low.get(), d_out.get(), size);
+    mp.calculate(d_high.get(), d_low.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_typprice(const float *host_high, const float *host_low,
-                       const float *host_close, float *host_output, int size) {
+                       const float *host_close, float *host_output, int size, cudaStream_t stream) {
   tacuda::TypPrice tp;
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_out{nullptr};
@@ -1546,39 +1596,45 @@ ctStatus_t ct_typprice(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_close.get(), host_close, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_close.get(), host_close, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    tp.calculate(d_high.get(), d_low.get(), d_close.get(), d_out.get(), size);
+    tp.calculate(d_high.get(), d_low.get(), d_close.get(), d_out.get(), size,
+                 stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_wclprice(const float *host_high, const float *host_low,
-                       const float *host_close, float *host_output, int size) {
+                       const float *host_close, float *host_output, int size, cudaStream_t stream) {
   tacuda::WclPrice wc;
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_out{nullptr};
@@ -1608,32 +1664,38 @@ ctStatus_t ct_wclprice(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_close.get(), host_close, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_close.get(), host_close, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    wc.calculate(d_high.get(), d_low.get(), d_close.get(), d_out.get(), size);
+    wc.calculate(d_high.get(), d_low.get(), d_close.get(), d_out.get(), size,
+                 stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
@@ -1641,7 +1703,7 @@ ctStatus_t ct_wclprice(const float *host_high, const float *host_low,
 
 ctStatus_t ct_willr(const float *host_high, const float *host_low,
                     const float *host_close, float *host_output, int size,
-                    int period) {
+                    int period, cudaStream_t stream) {
   tacuda::WILLR willr(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_out{nullptr};
@@ -1671,84 +1733,107 @@ ctStatus_t ct_willr(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_close.get(), host_close, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_close.get(), host_close, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
     willr.calculate(d_high.get(), d_low.get(), d_close.get(), d_out.get(),
-                    size);
+                    size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_midpoint(const float *host_input, float *host_output, int size,
-                       int period) {
+                       int period, cudaStream_t stream) {
   tacuda::MIDPOINT mp(period);
-  return run_indicator(mp, host_input, host_output, size);
+  return run_indicator(mp, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_midprice(const float *host_high, const float *host_low,
-                       float *host_output, int size, int period) {
+                       float *host_output, int size, int period, cudaStream_t stream) {
   tacuda::MIDPRICE mp(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
+
   cudaError_t err = cudaMalloc(&tmp, size * sizeof(float));
-  if (err != cudaSuccess)
+  if (err != cudaSuccess) {
     return CT_STATUS_ALLOC_FAILED;
+  }
   d_high.reset(tmp);
+
   err = cudaMalloc(&tmp, size * sizeof(float));
-  if (err != cudaSuccess)
+  if (err != cudaSuccess) {
     return CT_STATUS_ALLOC_FAILED;
+  }
   d_low.reset(tmp);
+
   err = cudaMalloc(&tmp, size * sizeof(float));
-  if (err != cudaSuccess)
+  if (err != cudaSuccess) {
     return CT_STATUS_ALLOC_FAILED;
+  }
   d_out.reset(tmp);
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
-  if (err != cudaSuccess)
+
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
+  if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
-  if (err != cudaSuccess)
+  }
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
+  if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
   try {
-    mp.calculate(d_high.get(), d_low.get(), d_out.get(), size);
+    mp.calculate(d_high.get(), d_low.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
-  if (err != cudaSuccess)
+
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
+  if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
+  }
+
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_ultosc(const float *host_high, const float *host_low,
                      const float *host_close, float *host_output, int size,
-                     int shortPeriod, int mediumPeriod, int longPeriod) {
+                     int shortPeriod, int mediumPeriod, int longPeriod, cudaStream_t stream) {
   tacuda::ULTOSC ultosc(shortPeriod, mediumPeriod, longPeriod);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_out{nullptr};
@@ -1778,33 +1863,38 @@ ctStatus_t ct_ultosc(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_close.get(), host_close, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_close.get(), host_close, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
     ultosc.calculate(d_high.get(), d_low.get(), d_close.get(), d_out.get(),
-                     size);
+                     size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
@@ -1812,7 +1902,7 @@ ctStatus_t ct_ultosc(const float *host_high, const float *host_low,
 
 ctStatus_t ct_mfi(const float *host_high, const float *host_low,
                   const float *host_close, const float *host_volume,
-                  float *host_output, int size, int period) {
+                  float *host_output, int size, int period, cudaStream_t stream) {
   tacuda::MFI mfi(period);
   DeviceBuffer d_high{nullptr}, d_low{nullptr}, d_close{nullptr},
       d_vol{nullptr}, d_out{nullptr};
@@ -1848,45 +1938,50 @@ ctStatus_t ct_mfi(const float *host_high, const float *host_low,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_high.get(), host_high, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_high.get(), host_high, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_low.get(), host_low, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_low.get(), host_low, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_close.get(), host_close, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_close.get(), host_close, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_vol.get(), host_volume, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_vol.get(), host_volume, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
     mfi.calculate(d_high.get(), d_low.get(), d_close.get(), d_vol.get(),
-                  d_out.get(), size);
+                  d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_obv(const float *host_price, const float *host_volume,
-                  float *host_output, int size) {
+                  float *host_output, int size, cudaStream_t stream) {
   tacuda::OBV obv;
   DeviceBuffer d_price{nullptr}, d_volume{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1909,34 +2004,39 @@ ctStatus_t ct_obv(const float *host_price, const float *host_volume,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_price.get(), host_price, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_price.get(), host_price, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_volume.get(), host_volume, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_volume.get(), host_volume, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    obv.calculate(d_price.get(), d_volume.get(), d_out.get(), size);
+    obv.calculate(d_price.get(), d_volume.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_beta(const float *host_x, const float *host_y, float *host_output,
-                   int size, int period) {
+                   int size, int period, cudaStream_t stream) {
   tacuda::Beta beta(period);
   DeviceBuffer d_x{nullptr}, d_y{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -1959,49 +2059,54 @@ ctStatus_t ct_beta(const float *host_x, const float *host_y, float *host_output,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_x.get(), host_x, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_x.get(), host_x, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_y.get(), host_y, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_y.get(), host_y, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    beta.calculate(d_x.get(), d_y.get(), d_out.get(), size);
+    beta.calculate(d_x.get(), d_y.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;
 }
 
 ctStatus_t ct_ht_dcperiod(const float *host_input, float *host_output,
-                          int size) {
+                          int size, cudaStream_t stream) {
   tacuda::HT_DCPERIOD ind;
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_ht_dcphase(const float *host_input, float *host_output,
-                         int size) {
+                         int size, cudaStream_t stream) {
   tacuda::HT_DCPHASE ind;
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_ht_phasor(const float *host_input, float *host_inphase,
-                        float *host_quadrature, int size) {
+                        float *host_quadrature, int size, cudaStream_t stream) {
   tacuda::HT_PHASOR ind;
   std::vector<float> tmp(2 * size);
-  ctStatus_t rc = run_indicator(ind, host_input, tmp.data(), size, 2);
+  ctStatus_t rc = run_indicator(ind, host_input, tmp.data(), size, 2, stream);
   if (rc != CT_STATUS_SUCCESS)
     return rc;
   std::memcpy(host_inphase, tmp.data(), size * sizeof(float));
@@ -2010,10 +2115,10 @@ ctStatus_t ct_ht_phasor(const float *host_input, float *host_inphase,
 }
 
 ctStatus_t ct_ht_sine(const float *host_input, float *host_sine,
-                      float *host_leadsine, int size) {
+                      float *host_leadsine, int size, cudaStream_t stream) {
   tacuda::HT_SINE ind;
   std::vector<float> tmp(2 * size);
-  ctStatus_t rc = run_indicator(ind, host_input, tmp.data(), size, 2);
+  ctStatus_t rc = run_indicator(ind, host_input, tmp.data(), size, 2, stream);
   if (rc != CT_STATUS_SUCCESS)
     return rc;
   std::memcpy(host_sine, tmp.data(), size * sizeof(float));
@@ -2022,600 +2127,600 @@ ctStatus_t ct_ht_sine(const float *host_input, float *host_sine,
 }
 
 ctStatus_t ct_ht_trendline(const float *host_input, float *host_output,
-                           int size) {
+                           int size, cudaStream_t stream) {
   tacuda::HT_TRENDLINE ind;
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_ht_trendmode(const float *host_input, float *host_output,
-                           int size) {
+                           int size, cudaStream_t stream) {
   tacuda::HT_TRENDMODE ind;
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_linearreg(const float *host_input, float *host_output, int size,
-                        int period) {
+                        int period, cudaStream_t stream) {
   tacuda::LINEARREG ind(period);
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_linearreg_slope(const float *host_input, float *host_output,
-                              int size, int period) {
+                              int size, int period, cudaStream_t stream) {
   tacuda::LINEARREG_SLOPE ind(period);
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_linearreg_intercept(const float *host_input, float *host_output,
-                                  int size, int period) {
+                                  int size, int period, cudaStream_t stream) {
   tacuda::LINEARREG_INTERCEPT ind(period);
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_linearreg_angle(const float *host_input, float *host_output,
-                              int size, int period) {
+                              int size, int period, cudaStream_t stream) {
   tacuda::LINEARREG_ANGLE ind(period);
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_tsf(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::TSF ind(period);
-  return run_indicator(ind, host_input, host_output, size);
+  return run_indicator(ind, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_bop(const float *host_open, const float *host_high,
                   const float *host_low, const float *host_close,
-                  float *host_output, int size) {
+                  float *host_output, int size, cudaStream_t stream) {
   tacuda::BOP bop;
   return run_ohlc_indicator(bop, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_doji(const float *host_open, const float *host_high,
                        const float *host_low, const float *host_close,
-                       float *host_output, int size) {
+                       float *host_output, int size, cudaStream_t stream) {
   tacuda::Doji ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_hammer(const float *host_open, const float *host_high,
                          const float *host_low, const float *host_close,
-                         float *host_output, int size) {
+                         float *host_output, int size, cudaStream_t stream) {
   tacuda::Hammer ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_inverted_hammer(const float *host_open,
                                   const float *host_high, const float *host_low,
                                   const float *host_close, float *host_output,
-                                  int size) {
+                                  int size, cudaStream_t stream) {
   tacuda::InvertedHammer ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_bullish_engulfing(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size) {
+                                    int size, cudaStream_t stream) {
   tacuda::BullishEngulfing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_bearish_engulfing(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size) {
+                                    int size, cudaStream_t stream) {
   tacuda::BearishEngulfing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_three_white_soldiers(const float *host_open,
                                        const float *host_high,
                                        const float *host_low,
                                        const float *host_close,
-                                       float *host_output, int size) {
+                                       float *host_output, int size, cudaStream_t stream) {
   tacuda::ThreeWhiteSoldiers ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_abandoned_baby(const float *host_open, const float *host_high,
                                  const float *host_low, const float *host_close,
-                                 float *host_output, int size) {
+                                 float *host_output, int size, cudaStream_t stream) {
   tacuda::AbandonedBaby ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_advance_block(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
-                                float *host_output, int size) {
+                                float *host_output, int size, cudaStream_t stream) {
   tacuda::AdvanceBlock ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_belt_hold(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
-                            float *host_output, int size) {
+                            float *host_output, int size, cudaStream_t stream) {
   tacuda::BeltHold ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_breakaway(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
-                            float *host_output, int size) {
+                            float *host_output, int size, cudaStream_t stream) {
   tacuda::Breakaway ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_two_crows(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
-                            float *host_output, int size) {
+                            float *host_output, int size, cudaStream_t stream) {
   tacuda::TwoCrows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_three_black_crows(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size) {
+                                    int size, cudaStream_t stream) {
   tacuda::ThreeBlackCrows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_three_inside(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
-                               float *host_output, int size) {
+                               float *host_output, int size, cudaStream_t stream) {
   tacuda::ThreeInside ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_three_line_strike(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size) {
+                                    int size, cudaStream_t stream) {
   tacuda::ThreeLineStrike ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_three_stars_in_south(const float *host_open,
                                        const float *host_high,
                                        const float *host_low,
                                        const float *host_close,
-                                       float *host_output, int size) {
+                                       float *host_output, int size, cudaStream_t stream) {
   tacuda::ThreeStarsInSouth ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_closing_marubozu(const float *host_open,
                                    const float *host_high,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
-                                   int size) {
+                                   int size, cudaStream_t stream) {
   tacuda::ClosingMarubozu ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_conceal_baby_swallow(const float *host_open,
                                        const float *host_high,
                                        const float *host_low,
                                        const float *host_close,
-                                       float *host_output, int size) {
+                                       float *host_output, int size, cudaStream_t stream) {
   tacuda::ConcealBabySwallow ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_counterattack(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
-                                float *host_output, int size) {
+                                float *host_output, int size, cudaStream_t stream) {
   tacuda::CounterAttack ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_dark_cloud_cover(const float *host_open,
                                    const float *host_high,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
-                                   int size) {
+                                   int size, cudaStream_t stream) {
   tacuda::DarkCloudCover ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_doji_star(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
-                            float *host_output, int size) {
+                            float *host_output, int size, cudaStream_t stream) {
   tacuda::DojiStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_dragonfly_doji(const float *host_open, const float *host_high,
                                  const float *host_low, const float *host_close,
-                                 float *host_output, int size) {
+                                 float *host_output, int size, cudaStream_t stream) {
   tacuda::DragonflyDoji ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_engulfing(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
-                            float *host_output, int size) {
+                            float *host_output, int size, cudaStream_t stream) {
   tacuda::Engulfing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_evening_doji_star(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size) {
+                                    int size, cudaStream_t stream) {
   tacuda::EveningDojiStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_evening_star(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
-                               float *host_output, int size) {
+                               float *host_output, int size, cudaStream_t stream) {
   tacuda::EveningStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_gap_side_side_white(const float *host_open,
                                       const float *host_high,
                                       const float *host_low,
                                       const float *host_close,
-                                      float *host_output, int size) {
+                                      float *host_output, int size, cudaStream_t stream) {
   tacuda::GapSideSideWhite ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_gravestone_doji(const float *host_open,
                                   const float *host_high, const float *host_low,
                                   const float *host_close, float *host_output,
-                                  int size) {
+                                  int size, cudaStream_t stream) {
   tacuda::GravestoneDoji ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_hanging_man(const float *host_open, const float *host_high,
                               const float *host_low, const float *host_close,
-                              float *host_output, int size) {
+                              float *host_output, int size, cudaStream_t stream) {
   tacuda::HangingMan ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_harami(const float *host_open, const float *host_high,
                          const float *host_low, const float *host_close,
-                         float *host_output, int size) {
+                         float *host_output, int size, cudaStream_t stream) {
   tacuda::Harami ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_harami_cross(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
-                               float *host_output, int size) {
+                               float *host_output, int size, cudaStream_t stream) {
   tacuda::HaramiCross ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_high_wave(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
-                            float *host_output, int size) {
+                            float *host_output, int size, cudaStream_t stream) {
   tacuda::HighWave ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_hikkake(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
-                          float *host_output, int size) {
+                          float *host_output, int size, cudaStream_t stream) {
   tacuda::Hikkake ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_hikkake_mod(const float *host_open, const float *host_high,
                               const float *host_low, const float *host_close,
-                              float *host_output, int size) {
+                              float *host_output, int size, cudaStream_t stream) {
   tacuda::HikkakeMod ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_homing_pigeon(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
-                                float *host_output, int size) {
+                                float *host_output, int size, cudaStream_t stream) {
   tacuda::HomingPigeon ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_identical_three_crows(const float *host_open,
                                         const float *host_high,
                                         const float *host_low,
                                         const float *host_close,
-                                        float *host_output, int size) {
+                                        float *host_output, int size, cudaStream_t stream) {
   tacuda::IdenticalThreeCrows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_in_neck(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
-                          float *host_output, int size) {
+                          float *host_output, int size, cudaStream_t stream) {
   tacuda::InNeck ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_kicking(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
-                          float *host_output, int size) {
+                          float *host_output, int size, cudaStream_t stream) {
   tacuda::Kicking ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_kicking_by_length(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size) {
+                                    int size, cudaStream_t stream) {
   tacuda::KickingByLength ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_ladder_bottom(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
-                                float *host_output, int size) {
+                                float *host_output, int size, cudaStream_t stream) {
   tacuda::LadderBottom ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_long_legged_doji(const float *host_open,
                                    const float *host_high,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
-                                   int size) {
+                                   int size, cudaStream_t stream) {
   tacuda::LongLeggedDoji ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_long_line(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
-                            float *host_output, int size) {
+                            float *host_output, int size, cudaStream_t stream) {
   tacuda::LongLine ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_marubozu(const float *host_open, const float *host_high,
                            const float *host_low, const float *host_close,
-                           float *host_output, int size) {
+                           float *host_output, int size, cudaStream_t stream) {
   tacuda::Marubozu ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_matching_low(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
-                               float *host_output, int size) {
+                               float *host_output, int size, cudaStream_t stream) {
   tacuda::MatchingLow ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_mat_hold(const float *host_open, const float *host_high,
                            const float *host_low, const float *host_close,
-                           float *host_output, int size) {
+                           float *host_output, int size, cudaStream_t stream) {
   tacuda::MatHold ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_morning_doji_star(const float *host_open,
                                     const float *host_high,
                                     const float *host_low,
                                     const float *host_close, float *host_output,
-                                    int size) {
+                                    int size, cudaStream_t stream) {
   tacuda::MorningDojiStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_morning_star(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
-                               float *host_output, int size) {
+                               float *host_output, int size, cudaStream_t stream) {
   tacuda::MorningStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_on_neck(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
-                          float *host_output, int size) {
+                          float *host_output, int size, cudaStream_t stream) {
   tacuda::OnNeck ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_piercing(const float *host_open, const float *host_high,
                            const float *host_low, const float *host_close,
-                           float *host_output, int size) {
+                           float *host_output, int size, cudaStream_t stream) {
   tacuda::Piercing ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_rickshaw_man(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
-                               float *host_output, int size) {
+                               float *host_output, int size, cudaStream_t stream) {
   tacuda::RickshawMan ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_rise_fall3_methods(const float *host_open,
                                      const float *host_high,
                                      const float *host_low,
                                      const float *host_close,
-                                     float *host_output, int size) {
+                                     float *host_output, int size, cudaStream_t stream) {
   tacuda::RiseFall3Methods ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_separating_lines(const float *host_open,
                                    const float *host_high,
                                    const float *host_low,
                                    const float *host_close, float *host_output,
-                                   int size) {
+                                   int size, cudaStream_t stream) {
   tacuda::SeparatingLines ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_shooting_star(const float *host_open, const float *host_high,
                                 const float *host_low, const float *host_close,
-                                float *host_output, int size) {
+                                float *host_output, int size, cudaStream_t stream) {
   tacuda::ShootingStar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_short_line(const float *host_open, const float *host_high,
                              const float *host_low, const float *host_close,
-                             float *host_output, int size) {
+                             float *host_output, int size, cudaStream_t stream) {
   tacuda::ShortLine ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_spinning_top(const float *host_open, const float *host_high,
                                const float *host_low, const float *host_close,
-                               float *host_output, int size) {
+                               float *host_output, int size, cudaStream_t stream) {
   tacuda::SpinningTop ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_stalled_pattern(const float *host_open,
                                   const float *host_high, const float *host_low,
                                   const float *host_close, float *host_output,
-                                  int size) {
+                                  int size, cudaStream_t stream) {
   tacuda::StalledPattern ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_stick_sandwich(const float *host_open, const float *host_high,
                                  const float *host_low, const float *host_close,
-                                 float *host_output, int size) {
+                                 float *host_output, int size, cudaStream_t stream) {
   tacuda::StickSandwich ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_takuri(const float *host_open, const float *host_high,
                          const float *host_low, const float *host_close,
-                         float *host_output, int size) {
+                         float *host_output, int size, cudaStream_t stream) {
   tacuda::Takuri ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_tasuki_gap(const float *host_open, const float *host_high,
                              const float *host_low, const float *host_close,
-                             float *host_output, int size) {
+                             float *host_output, int size, cudaStream_t stream) {
   tacuda::TasukiGap ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_thrusting(const float *host_open, const float *host_high,
                             const float *host_low, const float *host_close,
-                            float *host_output, int size) {
+                            float *host_output, int size, cudaStream_t stream) {
   tacuda::Thrusting ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_tristar(const float *host_open, const float *host_high,
                           const float *host_low, const float *host_close,
-                          float *host_output, int size) {
+                          float *host_output, int size, cudaStream_t stream) {
   tacuda::Tristar ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_unique_3_river(const float *host_open, const float *host_high,
                                  const float *host_low, const float *host_close,
-                                 float *host_output, int size) {
+                                 float *host_output, int size, cudaStream_t stream) {
   tacuda::Unique3River ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_upside_gap_2_crows(const float *host_open,
                                      const float *host_high,
                                      const float *host_low,
                                      const float *host_close,
-                                     float *host_output, int size) {
+                                     float *host_output, int size, cudaStream_t stream) {
   tacuda::UpsideGap2Crows ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cdl_xside_gap_3_methods(const float *host_open,
                                       const float *host_high,
                                       const float *host_low,
                                       const float *host_close,
-                                      float *host_output, int size) {
+                                      float *host_output, int size, cudaStream_t stream) {
   tacuda::XSideGap3Methods ind;
   return run_ohlc_indicator(ind, host_open, host_high, host_low, host_close,
-                            host_output, size);
+                            host_output, size, 1, stream);
 }
 
 ctStatus_t ct_cmo(const float *host_input, float *host_output, int size,
-                  int period) {
+                  int period, cudaStream_t stream) {
   tacuda::CMO cmo(period);
-  return run_indicator(cmo, host_input, host_output, size);
+  return run_indicator(cmo, host_input, host_output, size, 1, stream);
 }
 
 ctStatus_t ct_correl(const float *host_x, const float *host_y,
-                     float *host_output, int size, int period) {
+                     float *host_output, int size, int period, cudaStream_t stream) {
   tacuda::Correl correl(period);
   DeviceBuffer d_x{nullptr}, d_y{nullptr}, d_out{nullptr};
   float *tmp = nullptr;
@@ -2638,27 +2743,32 @@ ctStatus_t ct_correl(const float *host_x, const float *host_y,
   }
   d_out.reset(tmp);
 
-  err = cudaMemcpy(d_x.get(), host_x, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_x.get(), host_x, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
-  err = cudaMemcpy(d_y.get(), host_y, size * sizeof(float),
-                   cudaMemcpyHostToDevice);
+  err = cudaMemcpyAsync(d_y.get(), host_y, size * sizeof(float),
+                        cudaMemcpyHostToDevice, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
   }
 
   try {
-    correl.calculate(d_x.get(), d_y.get(), d_out.get(), size);
+    correl.calculate(d_x.get(), d_y.get(), d_out.get(), size, stream);
   } catch (...) {
     return CT_STATUS_KERNEL_FAILED;
   }
 
-  err = cudaMemcpy(host_output, d_out.get(), size * sizeof(float),
-                   cudaMemcpyDeviceToHost);
+  err = cudaMemcpyAsync(host_output, d_out.get(), size * sizeof(float),
+                        cudaMemcpyDeviceToHost, stream);
   if (err != cudaSuccess) {
     return CT_STATUS_COPY_FAILED;
+  }
+
+  err = cudaStreamSynchronize(stream);
+  if (err != cudaSuccess) {
+    return CT_STATUS_KERNEL_FAILED;
   }
 
   return CT_STATUS_SUCCESS;


### PR DESCRIPTION
## Summary
- add an optional `cudaStream_t` parameter to every host-facing `ct_*` declaration
- plumb the stream through `api.cpp`, passing it to `run_indicator` / `run_ohlc_indicator` and to manual wrappers with async copies

## Testing
- cmake -S . -B build *(fails: nvcc not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95045a06483298a56a9eefd27f91c