### PR TITLE
Add remaining TA-Lib indicators and bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,13 @@ option(BUILD_TESTING "Enable tests" ON)
 
 #Explicitly list indicator sources instead of globbing
 set(INDICATOR_SOURCES
+    src/indicators/ACCBANDS.cu
     src/indicators/MACD.cu
     src/indicators/MACDEXT.cu
     src/indicators/MACDFIX.cu
     src/indicators/detail/ema_common.cu
     src/indicators/Momentum.cu
+    src/indicators/MAVP.cu
     src/indicators/ROC.cu
     src/indicators/ROCP.cu
     src/indicators/ROCR.cu
@@ -25,6 +27,7 @@ set(INDICATOR_SOURCES
     src/indicators/TRIX.cu
     src/indicators/Change.cu
     src/indicators/StdDev.cu
+    src/indicators/AVGDEV.cu
     src/indicators/MA.cu
     src/indicators/MAX.cu
     src/indicators/MAXINDEX.cu
@@ -42,6 +45,7 @@ set(INDICATOR_SOURCES
     src/indicators/Aroon.cu
     src/indicators/ADOSC.cu
     src/indicators/MFI.cu
+    src/indicators/IMI.cu
     src/indicators/ULTOSC.cu
     src/indicators/AD.cu
     src/indicators/ADXR.cu
@@ -77,7 +81,9 @@ set(INDICATOR_SOURCES
     src/indicators/LINEARREG_INTERCEPT.cu
     src/indicators/LINEARREG_SLOPE.cu
     src/indicators/NATR.cu
+    src/indicators/NVI.cu
     src/indicators/PPO.cu
+    src/indicators/PVI.cu
     src/indicators/PVO.cu
     src/indicators/SUM.cu
     src/indicators/TRANGE.cu
@@ -107,6 +113,7 @@ set(INDICATOR_SOURCES
     src/indicators/ClosingMarubozu.cu
     src/indicators/ConcealBabySwallow.cu
     src/indicators/CounterAttack.cu
+    src/indicators/CDL3OUTSIDE.cu
     src/indicators/DarkCloudCover.cu
     src/indicators/DojiStar.cu
     src/indicators/DragonflyDoji.cu

--- a/bindings/csharp/Tacuda.Generated.cs
+++ b/bindings/csharp/Tacuda.Generated.cs
@@ -24,6 +24,9 @@ internal static partial class NativeMethods
     internal static extern int ct_ma(float[] host_input, float[] host_output, int size, int period, int type, IntPtr stream = default);
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ct_mavp(float[] host_input, float[] host_periods, float[] host_output, int size, int minPeriod, int maxPeriod, int type, IntPtr stream = default);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ct_wma(float[] host_input, float[] host_output, int size, int period, IntPtr stream = default);
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
@@ -82,6 +85,9 @@ internal static partial class NativeMethods
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ct_stddev(float[] host_input, float[] host_output, int size, int period, IntPtr stream = default);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ct_avgdev(float[] host_input, float[] host_output, int size, int period, IntPtr stream = default);
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ct_var(float[] host_input, float[] host_output, int size, int period, IntPtr stream = default);
@@ -201,6 +207,9 @@ internal static partial class NativeMethods
     internal static extern int ct_pvo_device(float[] device_volume, float[] device_output, int size, int fastPeriod, int slowPeriod, IntPtr stream = default);
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ct_accbands(float[] host_high, float[] host_low, float[] host_close, float[] host_upper, float[] host_middle, float[] host_lower, int size, int period, IntPtr stream = default);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ct_bbands(float[] host_input, float[] host_upper, float[] host_middle, float[] host_lower, int size, int period, float upperMul, float lowerMul, IntPtr stream = default);
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
@@ -246,7 +255,16 @@ internal static partial class NativeMethods
     internal static extern int ct_mfi(float[] host_high, float[] host_low, float[] host_close, float[] host_volume, float[] host_output, int size, int period, IntPtr stream = default);
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ct_imi(float[] host_open, float[] host_close, float[] host_output, int size, int period, IntPtr stream = default);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ct_obv(float[] host_price, float[] host_volume, float[] host_output, int size, IntPtr stream = default);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ct_nvi(float[] host_close, float[] host_volume, float[] host_output, int size, IntPtr stream = default);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ct_pvi(float[] host_close, float[] host_volume, float[] host_output, int size, IntPtr stream = default);
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ct_sar(float[] host_high, float[] host_low, float[] host_output, int size, float step, float maxAcceleration, IntPtr stream = default);
@@ -334,6 +352,9 @@ internal static partial class NativeMethods
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ct_cdl_three_inside(float[] host_open, float[] host_high, float[] host_low, float[] host_close, float[] host_output, int size, IntPtr stream = default);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int ct_cdl_three_outside(float[] host_open, float[] host_high, float[] host_low, float[] host_close, float[] host_output, int size, IntPtr stream = default);
 
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int ct_cdl_three_line_strike(float[] host_open, float[] host_high, float[] host_low, float[] host_close, float[] host_output, int size, IntPtr stream = default);

--- a/bindings/python/_generated.py
+++ b/bindings/python/_generated.py
@@ -44,6 +44,18 @@ FUNCTIONS = {
             ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
         ),
     ),
+    "mavp": FunctionSpec(
+        c_name="ct_mavp",
+        inputs=("host_input", "host_periods"),
+        outputs=("host_output",),
+        size_param="size",
+        scalars=(
+            ScalarParam(name="minPeriod", ctype="int"),
+            ScalarParam(name="maxPeriod", ctype="int"),
+            ScalarParam(name="type", ctype="ctMaType_t"),
+            ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
+        ),
+    ),
     "wma": FunctionSpec(
         c_name="ct_wma",
         inputs=("host_input",),
@@ -237,6 +249,16 @@ FUNCTIONS = {
     ),
     "stddev": FunctionSpec(
         c_name="ct_stddev",
+        inputs=("host_input",),
+        outputs=("host_output",),
+        size_param="size",
+        scalars=(
+            ScalarParam(name="period", ctype="int"),
+            ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
+        ),
+    ),
+    "avgdev": FunctionSpec(
+        c_name="ct_avgdev",
         inputs=("host_input",),
         outputs=("host_output",),
         size_param="size",
@@ -653,6 +675,16 @@ FUNCTIONS = {
             ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
         ),
     ),
+    "accbands": FunctionSpec(
+        c_name="ct_accbands",
+        inputs=("host_high", "host_low", "host_close"),
+        outputs=("host_upper", "host_middle", "host_lower"),
+        size_param="size",
+        scalars=(
+            ScalarParam(name="period", ctype="int"),
+            ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
+        ),
+    ),
     "bbands": FunctionSpec(
         c_name="ct_bbands",
         inputs=("host_input",),
@@ -809,9 +841,37 @@ FUNCTIONS = {
             ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
         ),
     ),
+    "imi": FunctionSpec(
+        c_name="ct_imi",
+        inputs=("host_open", "host_close"),
+        outputs=("host_output",),
+        size_param="size",
+        scalars=(
+            ScalarParam(name="period", ctype="int"),
+            ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
+        ),
+    ),
     "obv": FunctionSpec(
         c_name="ct_obv",
         inputs=("host_price", "host_volume"),
+        outputs=("host_output",),
+        size_param="size",
+        scalars=(
+            ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
+        ),
+    ),
+    "nvi": FunctionSpec(
+        c_name="ct_nvi",
+        inputs=("host_close", "host_volume"),
+        outputs=("host_output",),
+        size_param="size",
+        scalars=(
+            ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
+        ),
+    ),
+    "pvi": FunctionSpec(
+        c_name="ct_pvi",
+        inputs=("host_close", "host_volume"),
         outputs=("host_output",),
         size_param="size",
         scalars=(
@@ -1094,6 +1154,15 @@ FUNCTIONS = {
     ),
     "cdl_three_inside": FunctionSpec(
         c_name="ct_cdl_three_inside",
+        inputs=("host_open", "host_high", "host_low", "host_close"),
+        outputs=("host_output",),
+        size_param="size",
+        scalars=(
+            ScalarParam(name="stream", ctype="cudaStream_t", default="0"),
+        ),
+    ),
+    "cdl_three_outside": FunctionSpec(
+        c_name="ct_cdl_three_outside",
         inputs=("host_open", "host_high", "host_low", "host_close"),
         outputs=("host_output",),
         size_param="size",

--- a/include/indicators/ACCBANDS.h
+++ b/include/indicators/ACCBANDS.h
@@ -1,0 +1,20 @@
+#ifndef ACCBANDS_H
+#define ACCBANDS_H
+
+#include "Indicator.h"
+
+namespace tacuda {
+class ACCBANDS : public Indicator {
+public:
+    explicit ACCBANDS(int period);
+    void calculate(const float* high, const float* low, const float* close,
+                   float* output, int size, cudaStream_t stream = 0) noexcept(false);
+    void calculate(const float* input, float* output, int size,
+                   cudaStream_t stream = 0) noexcept(false) override;
+private:
+    int period;
+};
+
+} // namespace tacuda
+
+#endif

--- a/include/indicators/AVGDEV.h
+++ b/include/indicators/AVGDEV.h
@@ -1,0 +1,18 @@
+#ifndef AVGDEV_H
+#define AVGDEV_H
+
+#include "Indicator.h"
+
+namespace tacuda {
+class AVGDEV : public Indicator {
+public:
+    explicit AVGDEV(int period);
+    void calculate(const float* input, float* output, int size,
+                   cudaStream_t stream = 0) noexcept(false) override;
+private:
+    int period;
+};
+
+} // namespace tacuda
+
+#endif

--- a/include/indicators/CDL3OUTSIDE.h
+++ b/include/indicators/CDL3OUTSIDE.h
@@ -1,0 +1,19 @@
+#ifndef CDL3OUTSIDE_H
+#define CDL3OUTSIDE_H
+
+#include "Indicator.h"
+
+namespace tacuda {
+class CDL3OUTSIDE : public Indicator {
+public:
+    CDL3OUTSIDE() = default;
+    void calculate(const float* open, const float* high, const float* low,
+                   const float* close, float* output, int size,
+                   cudaStream_t stream = 0) noexcept(false);
+    void calculate(const float* input, float* output, int size,
+                   cudaStream_t stream = 0) noexcept(false) override;
+};
+
+} // namespace tacuda
+
+#endif

--- a/include/indicators/IMI.h
+++ b/include/indicators/IMI.h
@@ -1,0 +1,20 @@
+#ifndef IMI_H
+#define IMI_H
+
+#include "Indicator.h"
+
+namespace tacuda {
+class IMI : public Indicator {
+public:
+    explicit IMI(int period);
+    void calculate(const float* open, const float* close, float* output,
+                   int size, cudaStream_t stream = 0) noexcept(false);
+    void calculate(const float* input, float* output, int size,
+                   cudaStream_t stream = 0) noexcept(false) override;
+private:
+    int period;
+};
+
+} // namespace tacuda
+
+#endif

--- a/include/indicators/MAVP.h
+++ b/include/indicators/MAVP.h
@@ -1,0 +1,23 @@
+#ifndef MAVP_H
+#define MAVP_H
+
+#include "Indicator.h"
+#include "MA.h"
+
+namespace tacuda {
+class MAVP : public Indicator {
+public:
+    MAVP(int minPeriod, int maxPeriod, MAType type);
+    void calculate(const float* values, const float* periods, float* output,
+                   int size, cudaStream_t stream = 0) noexcept(false);
+    void calculate(const float* input, float* output, int size,
+                   cudaStream_t stream = 0) noexcept(false) override;
+private:
+    int minPeriod;
+    int maxPeriod;
+    MAType type;
+};
+
+} // namespace tacuda
+
+#endif

--- a/include/indicators/NVI.h
+++ b/include/indicators/NVI.h
@@ -1,0 +1,18 @@
+#ifndef NVI_H
+#define NVI_H
+
+#include "Indicator.h"
+
+namespace tacuda {
+class NVI : public Indicator {
+public:
+    NVI() = default;
+    void calculate(const float* close, const float* volume, float* output,
+                   int size, cudaStream_t stream = 0) noexcept(false);
+    void calculate(const float* input, float* output, int size,
+                   cudaStream_t stream = 0) noexcept(false) override;
+};
+
+} // namespace tacuda
+
+#endif

--- a/include/indicators/PVI.h
+++ b/include/indicators/PVI.h
@@ -1,0 +1,18 @@
+#ifndef PVI_H
+#define PVI_H
+
+#include "Indicator.h"
+
+namespace tacuda {
+class PVI : public Indicator {
+public:
+    PVI() = default;
+    void calculate(const float* close, const float* volume, float* output,
+                   int size, cudaStream_t stream = 0) noexcept(false);
+    void calculate(const float* input, float* output, int size,
+                   cudaStream_t stream = 0) noexcept(false) override;
+};
+
+} // namespace tacuda
+
+#endif

--- a/include/tacuda.h
+++ b/include/tacuda.h
@@ -35,6 +35,10 @@ CTAPI_EXPORT ctStatus_t ct_sma(const float *host_input, float *host_output,
                                int size, int period, cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_ma(const float *host_input, float *host_output,
                               int size, int period, ctMaType_t type, cudaStream_t stream CTAPI_STREAM_DEFAULT);
+CTAPI_EXPORT ctStatus_t ct_mavp(const float *host_input,
+                                const float *host_periods, float *host_output,
+                                int size, int minPeriod, int maxPeriod,
+                                ctMaType_t type, cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_wma(const float *host_input, float *host_output,
                                int size, int period, cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_momentum(const float *host_input, float *host_output,
@@ -75,6 +79,8 @@ CTAPI_EXPORT ctStatus_t ct_minmaxindex(const float *host_input,
                                        float *host_minidx, float *host_maxidx,
                                        int size, int period, cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_stddev(const float *host_input, float *host_output,
+                                  int size, int period, cudaStream_t stream CTAPI_STREAM_DEFAULT);
+CTAPI_EXPORT ctStatus_t ct_avgdev(const float *host_input, float *host_output,
                                   int size, int period, cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_var(const float *host_input, float *host_output,
                                int size, int period, cudaStream_t stream CTAPI_STREAM_DEFAULT);
@@ -197,6 +203,12 @@ CTAPI_EXPORT ctStatus_t ct_pvo_device(const float *device_volume,
                                       float *device_output, int size,
                                       int fastPeriod, int slowPeriod,
                                       cudaStream_t stream CTAPI_STREAM_DEFAULT);
+CTAPI_EXPORT ctStatus_t ct_accbands(const float *host_high,
+                                    const float *host_low,
+                                    const float *host_close,
+                                    float *host_upper, float *host_middle,
+                                    float *host_lower, int size, int period,
+                                    cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_bbands(const float *host_input, float *host_upper,
                                   float *host_middle, float *host_lower,
                                   int size, int period, float upperMul,
@@ -252,7 +264,16 @@ CTAPI_EXPORT ctStatus_t ct_mfi(const float *host_high, const float *host_low,
                                const float *host_close,
                                const float *host_volume, float *host_output,
                                int size, int period, cudaStream_t stream CTAPI_STREAM_DEFAULT);
+CTAPI_EXPORT ctStatus_t ct_imi(const float *host_open, const float *host_close,
+                               float *host_output, int size, int period,
+                               cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_obv(const float *host_price,
+                               const float *host_volume, float *host_output,
+                               int size, cudaStream_t stream CTAPI_STREAM_DEFAULT);
+CTAPI_EXPORT ctStatus_t ct_nvi(const float *host_close,
+                               const float *host_volume, float *host_output,
+                               int size, cudaStream_t stream CTAPI_STREAM_DEFAULT);
+CTAPI_EXPORT ctStatus_t ct_pvi(const float *host_close,
                                const float *host_volume, float *host_output,
                                int size, cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_sar(const float *host_high, const float *host_low,
@@ -374,6 +395,11 @@ CTAPI_EXPORT ctStatus_t ct_cdl_three_inside(const float *host_open,
                                             const float *host_low,
                                             const float *host_close,
                                             float *host_output, int size, cudaStream_t stream CTAPI_STREAM_DEFAULT);
+CTAPI_EXPORT ctStatus_t ct_cdl_three_outside(const float *host_open,
+                                             const float *host_high,
+                                             const float *host_low,
+                                             const float *host_close,
+                                             float *host_output, int size, cudaStream_t stream CTAPI_STREAM_DEFAULT);
 CTAPI_EXPORT ctStatus_t ct_cdl_three_line_strike(const float *host_open,
                                                  const float *host_high,
                                                  const float *host_low,

--- a/src/indicators/ACCBANDS.cu
+++ b/src/indicators/ACCBANDS.cu
@@ -1,0 +1,62 @@
+#include <indicators/ACCBANDS.h>
+#include <indicators/SMA.h>
+#include <utils/CudaUtils.h>
+#include <utils/DeviceBufferPool.h>
+#include <stdexcept>
+
+namespace {
+__global__ void accbandsPrepareKernel(const float* __restrict__ high,
+                                      const float* __restrict__ low,
+                                      float* __restrict__ upperRaw,
+                                      float* __restrict__ lowerRaw,
+                                      int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        float h = high[idx];
+        float l = low[idx];
+        float sum = h + l;
+        if (sum != 0.0f) {
+            float factor = 4.0f * (h - l) / sum;
+            upperRaw[idx] = h * (1.0f + factor);
+            lowerRaw[idx] = l * (1.0f - factor);
+        } else {
+            upperRaw[idx] = h;
+            lowerRaw[idx] = l;
+        }
+    }
+}
+} // namespace
+
+tacuda::ACCBANDS::ACCBANDS(int period) : period(period) {}
+
+void tacuda::ACCBANDS::calculate(const float* high, const float* low, const float* close,
+                                 float* output, int size, cudaStream_t stream) noexcept(false) {
+    if (period <= 0 || period > size) {
+        throw std::invalid_argument("ACCBANDS: invalid period");
+    }
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, 3 * size * sizeof(float), stream));
+    auto upperRaw = acquireDeviceBuffer<float>(size);
+    auto lowerRaw = acquireDeviceBuffer<float>(size);
+
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    accbandsPrepareKernel<<<grid, block, 0, stream>>>(high, low, upperRaw.get(), lowerRaw.get(), size);
+    CUDA_CHECK(cudaGetLastError());
+
+    float* upperOut = output;
+    float* middleOut = output + size;
+    float* lowerOut = output + 2 * size;
+
+    tacuda::SMA sma(period);
+    sma.calculate(close, middleOut, size, stream);
+    sma.calculate(upperRaw.get(), upperOut, size, stream);
+    sma.calculate(lowerRaw.get(), lowerOut, size, stream);
+}
+
+void tacuda::ACCBANDS::calculate(const float* input, float* output, int size,
+                                 cudaStream_t stream) noexcept(false) {
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(high, low, close, output, size, stream);
+}

--- a/src/indicators/AVGDEV.cu
+++ b/src/indicators/AVGDEV.cu
@@ -1,0 +1,38 @@
+#include <indicators/AVGDEV.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+#include <cmath>
+
+namespace {
+__global__ void avgdevKernel(const float* __restrict__ input,
+                             float* __restrict__ output,
+                             int period, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx <= size - period) {
+        float sum = 0.0f;
+        for (int i = 0; i < period; ++i) {
+            sum += input[idx + i];
+        }
+        float mean = sum / period;
+        float dev = 0.0f;
+        for (int i = 0; i < period; ++i) {
+            dev += fabsf(input[idx + i] - mean);
+        }
+        output[idx] = dev / period;
+    }
+}
+} // namespace
+
+tacuda::AVGDEV::AVGDEV(int period) : period(period) {}
+
+void tacuda::AVGDEV::calculate(const float* input, float* output, int size,
+                               cudaStream_t stream) noexcept(false) {
+    if (period <= 0 || period > size) {
+        throw std::invalid_argument("AVGDEV: invalid period");
+    }
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    avgdevKernel<<<grid, block, 0, stream>>>(input, output, period, size);
+    CUDA_CHECK(cudaGetLastError());
+}

--- a/src/indicators/CDL3OUTSIDE.cu
+++ b/src/indicators/CDL3OUTSIDE.cu
@@ -1,0 +1,59 @@
+#include <indicators/CDL3OUTSIDE.h>
+#include <utils/CandleUtils.h>
+#include <utils/CudaUtils.h>
+
+namespace {
+__device__ inline int candleColor(float open, float close) {
+    if (close > open) return 1;
+    if (close < open) return -1;
+    return 0;
+}
+
+__global__ void cdl3outsideKernel(const float* __restrict__ open,
+                                  const float* __restrict__ high,
+                                  const float* __restrict__ low,
+                                  const float* __restrict__ close,
+                                  float* __restrict__ output,
+                                  int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx > 1 && idx < size) {
+        int colorPrev1 = candleColor(open[idx - 1], close[idx - 1]);
+        int colorPrev2 = candleColor(open[idx - 2], close[idx - 2]);
+        bool bullish = colorPrev1 == 1 && colorPrev2 == -1 &&
+                       close[idx - 1] > open[idx - 2] &&
+                       open[idx - 1] < close[idx - 2] &&
+                       close[idx] > close[idx - 1];
+        bool bearish = colorPrev1 == -1 && colorPrev2 == 1 &&
+                       open[idx - 1] > close[idx - 2] &&
+                       close[idx - 1] < open[idx - 2] &&
+                       close[idx] < close[idx - 1];
+        if (bullish) {
+            output[idx] = 100.0f;
+        } else if (bearish) {
+            output[idx] = -100.0f;
+        } else {
+            output[idx] = 0.0f;
+        }
+    }
+}
+} // namespace
+
+void tacuda::CDL3OUTSIDE::calculate(const float* open, const float* high,
+                                    const float* low, const float* close,
+                                    float* output, int size,
+                                    cudaStream_t stream) noexcept(false) {
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    cdl3outsideKernel<<<grid, block, 0, stream>>>(open, high, low, close, output, size);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void tacuda::CDL3OUTSIDE::calculate(const float* input, float* output, int size,
+                                    cudaStream_t stream) noexcept(false) {
+    const float* open = input;
+    const float* high = input + size;
+    const float* low = input + 2 * size;
+    const float* close = input + 3 * size;
+    calculate(open, high, low, close, output, size, stream);
+}

--- a/src/indicators/IMI.cu
+++ b/src/indicators/IMI.cu
@@ -1,0 +1,77 @@
+#include <indicators/IMI.h>
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+#include <thrust/scan.h>
+#include <utils/CudaUtils.h>
+#include <utils/DeviceBufferPool.h>
+#include <stdexcept>
+
+namespace {
+__global__ void intradayDiffKernel(const float* __restrict__ open,
+                                   const float* __restrict__ close,
+                                   float* __restrict__ up,
+                                   float* __restrict__ down,
+                                   int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        float diff = close[idx] - open[idx];
+        if (diff > 0.0f) {
+            up[idx] = diff;
+            down[idx] = 0.0f;
+        } else {
+            up[idx] = 0.0f;
+            down[idx] = -diff;
+        }
+    }
+}
+
+__global__ void imiKernel(const float* __restrict__ prefixUp,
+                          const float* __restrict__ prefixDown,
+                          float* __restrict__ output,
+                          int period, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx <= size - period) {
+        int end = idx + period - 1;
+        float upPrev = (idx == 0) ? 0.0f : prefixUp[idx - 1];
+        float downPrev = (idx == 0) ? 0.0f : prefixDown[idx - 1];
+        float sumUp = prefixUp[end] - upPrev;
+        float sumDown = prefixDown[end] - downPrev;
+        float denom = sumUp + sumDown;
+        float value = (denom == 0.0f) ? 0.0f : 100.0f * (sumUp / denom);
+        output[idx] = value;
+    }
+}
+} // namespace
+
+tacuda::IMI::IMI(int period) : period(period) {}
+
+void tacuda::IMI::calculate(const float* open, const float* close, float* output,
+                            int size, cudaStream_t stream) noexcept(false) {
+    if (period <= 0 || period > size) {
+        throw std::invalid_argument("IMI: invalid period");
+    }
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
+
+    auto up = acquireDeviceBuffer<float>(size);
+    auto down = acquireDeviceBuffer<float>(size);
+
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    intradayDiffKernel<<<grid, block, 0, stream>>>(open, close, up.get(), down.get(), size);
+    CUDA_CHECK(cudaGetLastError());
+
+    thrust::device_ptr<float> upPtr(up.get());
+    thrust::device_ptr<float> downPtr(down.get());
+    thrust::inclusive_scan(thrust::cuda::par.on(stream), upPtr, upPtr + size, upPtr);
+    thrust::inclusive_scan(thrust::cuda::par.on(stream), downPtr, downPtr + size, downPtr);
+
+    imiKernel<<<grid, block, 0, stream>>>(up.get(), down.get(), output, period, size);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void tacuda::IMI::calculate(const float* input, float* output, int size,
+                            cudaStream_t stream) noexcept(false) {
+    const float* open = input;
+    const float* close = input + 3 * size; // assuming OHLC layout
+    calculate(open, close, output, size, stream);
+}

--- a/src/indicators/MAVP.cu
+++ b/src/indicators/MAVP.cu
@@ -1,0 +1,80 @@
+#include <algorithm>
+#include <indicators/MAVP.h>
+#include <utils/CudaUtils.h>
+#include <utils/DeviceBufferPool.h>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+__global__ void clampPeriodsKernel(const float* __restrict__ periods,
+                                   int* __restrict__ clamped,
+                                   int size, int minP, int maxP) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        int p = static_cast<int>(periods[idx]);
+        if (p < minP) p = minP;
+        if (p > maxP) p = maxP;
+        clamped[idx] = p;
+    }
+}
+
+__global__ void scatterMavpKernel(const float* __restrict__ values,
+                                  const int* __restrict__ periods,
+                                  float* __restrict__ output,
+                                  int size, int period) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size && periods[idx] == period) {
+        if (idx <= size - period) {
+            output[idx] = values[idx];
+        }
+    }
+}
+} // namespace
+
+tacuda::MAVP::MAVP(int minPeriod, int maxPeriod, MAType type)
+    : minPeriod(minPeriod), maxPeriod(maxPeriod), type(type) {
+    if (minPeriod <= 0 || maxPeriod <= 0 || minPeriod > maxPeriod) {
+        throw std::invalid_argument("MAVP: invalid period range");
+    }
+}
+
+void tacuda::MAVP::calculate(const float* values, const float* periods, float* output,
+                             int size, cudaStream_t stream) noexcept(false) {
+    if (size <= 0) {
+        throw std::invalid_argument("MAVP: invalid size");
+    }
+    if (maxPeriod > size) {
+        throw std::invalid_argument("MAVP: maxPeriod exceeds size");
+    }
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
+
+    auto devicePeriods = acquireDeviceBuffer<int>(size);
+    dim3 block = defaultBlock();
+    dim3 grid = defaultGrid(size);
+    clampPeriodsKernel<<<grid, block, 0, stream>>>(periods, devicePeriods.get(), size, minPeriod, maxPeriod);
+    CUDA_CHECK(cudaGetLastError());
+
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    std::vector<int> hostPeriods(size);
+    CUDA_CHECK(cudaMemcpy(hostPeriods.data(), devicePeriods.get(),
+                          size * sizeof(int), cudaMemcpyDeviceToHost));
+
+    std::vector<int> uniquePeriods = hostPeriods;
+    std::sort(uniquePeriods.begin(), uniquePeriods.end());
+    uniquePeriods.erase(std::unique(uniquePeriods.begin(), uniquePeriods.end()), uniquePeriods.end());
+
+    for (int period : uniquePeriods) {
+        tacuda::MA ma(period, type);
+        auto tmp = acquireDeviceBuffer<float>(size);
+        ma.calculate(values, tmp.get(), size, stream);
+        scatterMavpKernel<<<grid, block, 0, stream>>>(tmp.get(), devicePeriods.get(), output, size, period);
+        CUDA_CHECK(cudaGetLastError());
+    }
+}
+
+void tacuda::MAVP::calculate(const float* input, float* output, int size,
+                             cudaStream_t stream) noexcept(false) {
+    const float* values = input;
+    const float* periods = input + size;
+    calculate(values, periods, output, size, stream);
+}

--- a/src/indicators/NVI.cu
+++ b/src/indicators/NVI.cu
@@ -1,0 +1,46 @@
+#include <indicators/NVI.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+
+namespace {
+__global__ void nviKernel(const float* __restrict__ close,
+                          const float* __restrict__ volume,
+                          float* __restrict__ output,
+                          int size) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        if (size <= 0) {
+            return;
+        }
+        float prevIndex = 1000.0f;
+        output[0] = prevIndex;
+        for (int i = 1; i < size; ++i) {
+            float prevVol = volume[i - 1];
+            float currVol = volume[i];
+            float prevClose = close[i - 1];
+            float value = prevIndex;
+            if (currVol < prevVol && prevClose != 0.0f) {
+                value = prevIndex * (1.0f + (close[i] - prevClose) / prevClose);
+            }
+            output[i] = value;
+            prevIndex = value;
+        }
+    }
+}
+} // namespace
+
+void tacuda::NVI::calculate(const float* close, const float* volume, float* output,
+                            int size, cudaStream_t stream) noexcept(false) {
+    if (size <= 0) {
+        throw std::invalid_argument("NVI: invalid size");
+    }
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
+    nviKernel<<<1, 1, 0, stream>>>(close, volume, output, size);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void tacuda::NVI::calculate(const float* input, float* output, int size,
+                            cudaStream_t stream) noexcept(false) {
+    const float* close = input;
+    const float* volume = input + size;
+    calculate(close, volume, output, size, stream);
+}

--- a/src/indicators/PVI.cu
+++ b/src/indicators/PVI.cu
@@ -1,0 +1,46 @@
+#include <indicators/PVI.h>
+#include <utils/CudaUtils.h>
+#include <stdexcept>
+
+namespace {
+__global__ void pviKernel(const float* __restrict__ close,
+                          const float* __restrict__ volume,
+                          float* __restrict__ output,
+                          int size) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        if (size <= 0) {
+            return;
+        }
+        float prevIndex = 1000.0f;
+        output[0] = prevIndex;
+        for (int i = 1; i < size; ++i) {
+            float prevVol = volume[i - 1];
+            float currVol = volume[i];
+            float prevClose = close[i - 1];
+            float value = prevIndex;
+            if (currVol > prevVol && prevClose != 0.0f) {
+                value = prevIndex * (1.0f + (close[i] - prevClose) / prevClose);
+            }
+            output[i] = value;
+            prevIndex = value;
+        }
+    }
+}
+} // namespace
+
+void tacuda::PVI::calculate(const float* close, const float* volume, float* output,
+                            int size, cudaStream_t stream) noexcept(false) {
+    if (size <= 0) {
+        throw std::invalid_argument("PVI: invalid size");
+    }
+    CUDA_CHECK(cudaMemsetAsync(output, 0xFF, size * sizeof(float), stream));
+    pviKernel<<<1, 1, 0, stream>>>(close, volume, output, size);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void tacuda::PVI::calculate(const float* input, float* output, int size,
+                            cudaStream_t stream) noexcept(false) {
+    const float* close = input;
+    const float* volume = input + size;
+    calculate(close, volume, output, size, stream);
+}

--- a/tests/cpp/test_new_indicators.cpp
+++ b/tests/cpp/test_new_indicators.cpp
@@ -1,0 +1,141 @@
+#include <tacuda.h>
+#include "test_utils.hpp"
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+TEST(Tacuda, AvgDev) {
+  const int N = 6;
+  const int period = 3;
+  std::vector<float> data{1.0f, 2.0f, 4.0f, 7.0f, 11.0f, 16.0f};
+  std::vector<float> out(N, 0.0f);
+  ASSERT_EQ(ct_avgdev(data.data(), out.data(), N, period), CT_STATUS_SUCCESS);
+  std::vector<float> ref(N, std::numeric_limits<float>::quiet_NaN());
+  for (int i = 0; i <= N - period; ++i) {
+    float sum = 0.0f;
+    for (int j = 0; j < period; ++j) sum += data[i + j];
+    float mean = sum / period;
+    float dev = 0.0f;
+    for (int j = 0; j < period; ++j) dev += std::fabs(data[i + j] - mean);
+    ref[i] = dev / period;
+  }
+  expect_approx_equal(out, ref);
+  for (int i = N - period + 1; i < N; ++i) {
+    EXPECT_TRUE(std::isnan(out[i]));
+  }
+}
+
+TEST(Tacuda, MAVP) {
+  const int N = 5;
+  std::vector<float> data{1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+  std::vector<float> periods{2.0f, 2.5f, 3.0f, 3.0f, 2.0f};
+  std::vector<float> out(N, 0.0f);
+  ASSERT_EQ(ct_mavp(data.data(), periods.data(), out.data(), N, 2, 3, CT_MA_SMA),
+            CT_STATUS_SUCCESS);
+  std::vector<float> ref(N, std::numeric_limits<float>::quiet_NaN());
+  ref[0] = (data[0] + data[1]) / 2.0f;
+  ref[1] = (data[1] + data[2]) / 2.0f;
+  ref[2] = (data[2] + data[3] + data[4]) / 3.0f;
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[3]));
+  EXPECT_TRUE(std::isnan(out[4]));
+}
+
+TEST(Tacuda, NVI) {
+  std::vector<float> close{1.0f, 2.0f, 1.5f, 1.8f};
+  std::vector<float> volume{100.0f, 90.0f, 95.0f, 80.0f};
+  std::vector<float> out(close.size(), 0.0f);
+  ASSERT_EQ(ct_nvi(close.data(), volume.data(), out.data(), close.size()),
+            CT_STATUS_SUCCESS);
+  std::vector<float> ref{1000.0f, 2000.0f, 2000.0f,
+                         2000.0f * (1.0f + (1.8f - 1.5f) / 1.5f)};
+  expect_approx_equal(out, ref);
+}
+
+TEST(Tacuda, PVI) {
+  std::vector<float> close{1.0f, 1.2f, 1.1f, 1.3f};
+  std::vector<float> volume{100.0f, 120.0f, 110.0f, 150.0f};
+  std::vector<float> out(close.size(), 0.0f);
+  ASSERT_EQ(ct_pvi(close.data(), volume.data(), out.data(), close.size()),
+            CT_STATUS_SUCCESS);
+  std::vector<float> ref(close.size(), 0.0f);
+  ref[0] = 1000.0f;
+  ref[1] = 1000.0f * (1.0f + (1.2f - 1.0f) / 1.0f);
+  ref[2] = ref[1];
+  ref[3] = ref[2] * (1.0f + (1.3f - 1.1f) / 1.1f);
+  expect_approx_equal(out, ref);
+}
+
+TEST(Tacuda, IMI) {
+  const int N = 5;
+  std::vector<float> open{1.0f, 2.0f, 1.0f, 1.5f, 1.2f};
+  std::vector<float> close{1.5f, 1.5f, 0.8f, 1.6f, 1.0f};
+  std::vector<float> out(N, 0.0f);
+  ASSERT_EQ(ct_imi(open.data(), close.data(), out.data(), N, 3), CT_STATUS_SUCCESS);
+  std::vector<float> ref(N, std::numeric_limits<float>::quiet_NaN());
+  ref[0] = 100.0f * (0.5f / 1.2f);
+  ref[1] = 100.0f * (0.1f / 0.8f);
+  ref[2] = 100.0f * (0.1f / 0.5f);
+  expect_approx_equal(out, ref);
+  EXPECT_TRUE(std::isnan(out[3]));
+  EXPECT_TRUE(std::isnan(out[4]));
+}
+
+TEST(Tacuda, ACCBANDS) {
+  const int N = 6;
+  const int period = 3;
+  std::vector<float> high{10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f};
+  std::vector<float> low{9.0f, 9.5f, 10.0f, 11.0f, 12.0f, 13.0f};
+  std::vector<float> close{9.5f, 10.5f, 11.0f, 12.5f, 13.0f, 14.0f};
+  std::vector<float> upper(N), middle(N), lower(N);
+  ASSERT_EQ(ct_accbands(high.data(), low.data(), close.data(), upper.data(),
+                        middle.data(), lower.data(), N, period), CT_STATUS_SUCCESS);
+  std::vector<float> rawUpper(N), rawLower(N);
+  for (int i = 0; i < N; ++i) {
+    float h = high[i];
+    float l = low[i];
+    float sum = h + l;
+    if (sum != 0.0f) {
+      float factor = 4.0f * (h - l) / sum;
+      rawUpper[i] = h * (1.0f + factor);
+      rawLower[i] = l * (1.0f - factor);
+    } else {
+      rawUpper[i] = h;
+      rawLower[i] = l;
+    }
+  }
+  std::vector<float> refUpper(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> refMiddle(N, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> refLower(N, std::numeric_limits<float>::quiet_NaN());
+  for (int i = 0; i <= N - period; ++i) {
+    float sumU = 0.0f, sumM = 0.0f, sumL = 0.0f;
+    for (int j = 0; j < period; ++j) {
+      sumU += rawUpper[i + j];
+      sumM += close[i + j];
+      sumL += rawLower[i + j];
+    }
+    refUpper[i] = sumU / period;
+    refMiddle[i] = sumM / period;
+    refLower[i] = sumL / period;
+  }
+  expect_approx_equal(upper, refUpper);
+  expect_approx_equal(middle, refMiddle);
+  expect_approx_equal(lower, refLower);
+}
+
+TEST(Tacuda, CDLThreeOutside) {
+  const int N = 5;
+  std::vector<float> open{10.0f, 8.5f, 10.4f, 11.5f, 9.4f};
+  std::vector<float> high{10.5f, 11.0f, 11.5f, 11.8f, 9.6f};
+  std::vector<float> low{9.5f, 8.3f, 10.2f, 9.0f, 8.5f};
+  std::vector<float> close{9.0f, 10.6f, 11.2f, 9.5f, 8.8f};
+  std::vector<float> out(N, 0.0f);
+  ASSERT_EQ(ct_cdl_three_outside(open.data(), high.data(), low.data(), close.data(),
+                                out.data(), N, 0), CT_STATUS_SUCCESS);
+  EXPECT_TRUE(std::isnan(out[0]));
+  EXPECT_TRUE(std::isnan(out[1]));
+  EXPECT_FLOAT_EQ(100.0f, out[2]);
+  EXPECT_FLOAT_EQ(0.0f, out[3]);
+  EXPECT_FLOAT_EQ(-100.0f, out[4]);
+}


### PR DESCRIPTION
## Summary
- implement CUDA versions of ACCBANDS, MAVP, NVI, PVI, IMI, CDL3OUTSIDE, and AVGDEV with new headers and kernels
- expose new indicators through the C API, regenerate bindings, and add comprehensive unit tests covering each addition
- extend the build configuration to compile the new sources

## Testing
- `cmake -S . -B build` *(fails: nvcc toolchain is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e830c6788329b67cc403c144639c